### PR TITLE
Make the Automaton trait generic over the pattern type

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,18 +10,18 @@ use test::Bencher;
 
 const HAYSTACK_RANDOM: &'static str = include_str!("random.txt");
 
-fn bench_aut_no_match<T: Transitions>(
+fn bench_aut_no_match<P: AsRef<[u8]>, T: Transitions>(
     b: &mut Bencher,
-    aut: AcAutomaton<T>,
+    aut: AcAutomaton<P, T>,
     haystack: &str,
 ) {
     b.bytes = haystack.len() as u64;
     b.iter(|| assert!(aut.find(haystack).next().is_none()));
 }
 
-fn bench_full_aut_no_match<T: Transitions>(
+fn bench_full_aut_no_match<P: AsRef<[u8]>, T: Transitions>(
     b: &mut Bencher,
-    aut: AcAutomaton<T>,
+    aut: AcAutomaton<P, T>,
     haystack: &str,
 ) {
     let aut = aut.into_full();
@@ -149,7 +149,7 @@ fn ac_ten_one_prefix_byte_random(b: &mut Bencher) {
 }}}
 
 aut_benches!(dense, AcAutomaton::new, bench_aut_no_match);
-aut_benches!(sparse, AcAutomaton::<Sparse>::with_transitions,
+aut_benches!(sparse, AcAutomaton::<&str, Sparse>::with_transitions,
              bench_aut_no_match);
 aut_benches!(full, AcAutomaton::new, bench_full_aut_no_match);
 

--- a/examples/dict-search.rs
+++ b/examples/dict-search.rs
@@ -60,7 +60,7 @@ fn run(args: &Args) -> Result<(), Box<Error>> {
 }
 
 fn write_matches<A, I>(aut: &A, it: I) -> Result<(), Box<Error>>
-        where A: Automaton, I: Iterator<Item=io::Result<Match>> {
+        where A: Automaton<String>, I: Iterator<Item=io::Result<Match>> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
     try!(wtr.encode(("pattern", "start", "end")));
     for m in it {

--- a/examples/dict-search.rs
+++ b/examples/dict-search.rs
@@ -74,7 +74,7 @@ fn write_matches<A, I>(aut: &A, it: I) -> Result<(), Box<Error>>
 fn build_automaton(
     dict_path: &str,
     min_len: usize,
-) -> Result<AcAutomaton, Box<Error>> {
+) -> Result<AcAutomaton<String>, Box<Error>> {
     let buf = io::BufReader::new(try!(File::open(dict_path)));
     let mut lines = Vec::with_capacity(1 << 10);
     for line in buf.lines() {

--- a/src/autiter.rs
+++ b/src/autiter.rs
@@ -1,9 +1,10 @@
 use std::io::{self, BufRead, Read};
+use std::marker::PhantomData;
 
 use super::{ROOT_STATE, PatIdx, StateIdx};
 
 /// An abstraction over automatons and their corresponding iterators.
-pub trait Automaton: Sized {
+pub trait Automaton<P>: Sized {
     /// Return the next state given the current state and next character.
     fn next_state(&self, si: StateIdx, b: u8) -> StateIdx;
 
@@ -29,13 +30,13 @@ pub trait Automaton: Sized {
     /// Returns all of the patterns matched by this automaton.
     ///
     /// The order of the patterns is the order in which they were added.
-    fn patterns(&self) -> &[String];
+    fn patterns(&self) -> &[P];
 
     /// Returns the pattern indexed at `i`.
     ///
     /// The index corresponds to the position at which the pattern was added
     /// to the automaton, starting at `0`.
-    fn pattern(&self, i: usize) -> &str;
+    fn pattern(&self, i: usize) -> &P;
 
     /// Return the number of patterns in the automaton.
     #[inline]
@@ -53,12 +54,13 @@ pub trait Automaton: Sized {
     fn find<'a, 's>(
         &'a self,
         s: &'s str,
-    ) -> Matches<'a, 's, Self> {
+    ) -> Matches<'a, 's, P, Self> {
         Matches {
             aut: self,
             text: s.as_bytes(),
             texti: 0,
             si: ROOT_STATE,
+            _m: PhantomData,
         }
     }
 
@@ -66,13 +68,14 @@ pub trait Automaton: Sized {
     fn find_overlapping<'a, 's>(
         &'a self,
         s: &'s str,
-    ) -> MatchesOverlapping<'a, 's, Self> {
+    ) -> MatchesOverlapping<'a, 's, P, Self> {
         MatchesOverlapping {
             aut: self,
             text: s.as_bytes(),
             texti: 0,
             si: ROOT_STATE,
             outi: 0,
+            _m: PhantomData,
         }
     }
 
@@ -80,12 +83,13 @@ pub trait Automaton: Sized {
     fn stream_find<'a, R: io::Read>(
         &'a self,
         rdr: R,
-    ) -> StreamMatches<'a, R, Self> {
+    ) -> StreamMatches<'a, R, P, Self> {
         StreamMatches {
             aut: self,
             buf: io::BufReader::new(rdr),
             texti: 0,
             si: ROOT_STATE,
+            _m: PhantomData,
         }
     }
 
@@ -93,13 +97,14 @@ pub trait Automaton: Sized {
     fn stream_find_overlapping<'a, R: io::Read>(
         &'a self,
         rdr: R,
-    ) -> StreamMatchesOverlapping<'a, R, Self> {
+    ) -> StreamMatchesOverlapping<'a, R, P, Self> {
         StreamMatchesOverlapping {
             aut: self,
             buf: io::BufReader::new(rdr),
             texti: 0,
             si: ROOT_STATE,
             outi: 0,
+            _m: PhantomData,
         }
     }
 }
@@ -128,14 +133,15 @@ pub struct Match {
 /// `'a` is the lifetime of the automaton and `'s` is the lifetime of the
 /// search text.
 #[derive(Debug)]
-pub struct Matches<'a, 's, A: 'a + Automaton> {
+pub struct Matches<'a, 's, P, A: 'a + Automaton<P>> {
     aut: &'a A,
     text: &'s [u8],
     texti: usize,
     si: StateIdx,
+    _m: PhantomData<P>,
 }
 
-impl<'a, 's, A: Automaton> Iterator for Matches<'a, 's, A> {
+impl<'a, 's, P, A: Automaton<P>> Iterator for Matches<'a, 's, P, A> {
     type Item = Match;
 
     fn next(&mut self) -> Option<Match> {
@@ -181,14 +187,15 @@ impl<'a, 's, A: Automaton> Iterator for Matches<'a, 's, A> {
 /// `'a` is the lifetime of the automaton and `R` is the type of the underlying
 /// `io::Read`er.
 #[derive(Debug)]
-pub struct StreamMatches<'a, R, A: 'a + Automaton> {
+pub struct StreamMatches<'a, R, P, A: 'a + Automaton<P>> {
     aut: &'a A,
     buf: io::BufReader<R>,
     texti: usize,
     si: StateIdx,
+    _m: PhantomData<P>,
 }
 
-impl<'a, R: io::Read, A: Automaton> Iterator for StreamMatches<'a, R, A> {
+impl<'a, R: io::Read, P, A: Automaton<P>> Iterator for StreamMatches<'a, R, P, A> {
     type Item = io::Result<Match>;
 
     fn next(&mut self) -> Option<io::Result<Match>> {
@@ -226,15 +233,16 @@ impl<'a, R: io::Read, A: Automaton> Iterator for StreamMatches<'a, R, A> {
 /// `'a` is the lifetime of the automaton and `'s` is the lifetime of the
 /// search text.
 #[derive(Debug)]
-pub struct MatchesOverlapping<'a, 's, A: 'a + Automaton> {
+pub struct MatchesOverlapping<'a, 's, P, A: 'a + Automaton<P>> {
     aut: &'a A,
     text: &'s [u8],
     texti: usize,
     si: StateIdx,
     outi: usize,
+    _m: PhantomData<P>,
 }
 
-impl<'a, 's, A: Automaton> Iterator for MatchesOverlapping<'a, 's, A> {
+impl<'a, 's, P, A: Automaton<P>> Iterator for MatchesOverlapping<'a, 's, P, A> {
     type Item = Match;
 
     fn next(&mut self) -> Option<Match> {
@@ -268,19 +276,21 @@ impl<'a, 's, A: Automaton> Iterator for MatchesOverlapping<'a, 's, A> {
 /// `'a` is the lifetime of the automaton and `R` is the type of the underlying
 /// `io::Read`er.
 #[derive(Debug)]
-pub struct StreamMatchesOverlapping<'a, R, A: 'a + Automaton> {
+pub struct StreamMatchesOverlapping<'a, R, P, A: 'a + Automaton<P>> {
     aut: &'a A,
     buf: io::BufReader<R>,
     texti: usize,
     si: StateIdx,
     outi: usize,
+    _m: PhantomData<P>,
 }
 
 impl<
     'a,
     R: io::Read,
-    A: Automaton,
-> Iterator for StreamMatchesOverlapping<'a, R, A> {
+    P,
+    A: Automaton<P>,
+> Iterator for StreamMatchesOverlapping<'a, R, P, A> {
     type Item = io::Result<Match>;
 
     fn next(&mut self) -> Option<io::Result<Match>> {

--- a/src/autiter.rs
+++ b/src/autiter.rs
@@ -4,6 +4,8 @@ use std::marker::PhantomData;
 use super::{ROOT_STATE, PatIdx, StateIdx};
 
 /// An abstraction over automatons and their corresponding iterators.
+/// The type parameter `P` is the type of the pattern that was used to
+/// construct this Automaton.
 pub trait Automaton<P>: Sized {
     /// Return the next state given the current state and next character.
     fn next_state(&self, si: StateIdx, b: u8) -> StateIdx;
@@ -130,8 +132,8 @@ pub struct Match {
 ///
 /// This iterator yields `Match` values.
 ///
-/// `'a` is the lifetime of the automaton and `'s` is the lifetime of the
-/// search text.
+/// `'a` is the lifetime of the automaton, `'s` is the lifetime of the
+/// search text, and `P` is the type of the Automaton's pattern.
 #[derive(Debug)]
 pub struct Matches<'a, 's, P, A: 'a + Automaton<P>> {
     aut: &'a A,
@@ -184,8 +186,8 @@ impl<'a, 's, P, A: Automaton<P>> Iterator for Matches<'a, 's, P, A> {
 ///
 /// This iterator yields `io::Result<Match>` values.
 ///
-/// `'a` is the lifetime of the automaton and `R` is the type of the underlying
-/// `io::Read`er.
+/// `'a` is the lifetime of the automaton, `R` is the type of the underlying
+/// `io::Read`er, and P is the type of the Automaton's pattern.
 #[derive(Debug)]
 pub struct StreamMatches<'a, R, P, A: 'a + Automaton<P>> {
     aut: &'a A,
@@ -230,8 +232,8 @@ impl<'a, R: io::Read, P, A: Automaton<P>> Iterator for StreamMatches<'a, R, P, A
 ///
 /// This iterator yields `Match` values.
 ///
-/// `'a` is the lifetime of the automaton and `'s` is the lifetime of the
-/// search text.
+/// `'a` is the lifetime of the automaton, `'s` is the lifetime of the
+/// search text, and `P` is the type of the Automaton's pattern.
 #[derive(Debug)]
 pub struct MatchesOverlapping<'a, 's, P, A: 'a + Automaton<P>> {
     aut: &'a A,
@@ -273,8 +275,8 @@ impl<'a, 's, P, A: Automaton<P>> Iterator for MatchesOverlapping<'a, 's, P, A> {
 ///
 /// This iterator yields `io::Result<Match>` values.
 ///
-/// `'a` is the lifetime of the automaton and `R` is the type of the underlying
-/// `io::Read`er.
+/// `'a` is the lifetime of the automaton, `R` is the type of the underlying
+/// `io::Read`er, and P is the type of the Automaton's pattern.
 #[derive(Debug)]
 pub struct StreamMatchesOverlapping<'a, R, P, A: 'a + Automaton<P>> {
     aut: &'a A,
@@ -332,4 +334,3 @@ impl<
         m
     }
 }
-

--- a/src/full.rs
+++ b/src/full.rs
@@ -52,7 +52,7 @@ impl FullAcAutomaton {
     }
 }
 
-impl Automaton for FullAcAutomaton {
+impl Automaton<String> for FullAcAutomaton {
     #[inline]
     fn next_state(&self, si: StateIdx, i: u8) -> StateIdx {
         self.trans[i as usize * self.num_states() + si as usize]
@@ -98,7 +98,7 @@ impl Automaton for FullAcAutomaton {
     }
 
     #[inline]
-    fn pattern(&self, i: usize) -> &str {
+    fn pattern(&self, i: usize) -> &String {
         &self.pats[i]
     }
 }

--- a/src/full.rs
+++ b/src/full.rs
@@ -61,7 +61,7 @@ impl<P: AsRef<[u8]>> Automaton<P> for FullAcAutomaton<P> {
     #[inline]
     fn get_match(&self, si: StateIdx, outi: usize, texti: usize) -> Match {
         let pati = self.out[si as usize][outi];
-        let patlen = self.pats[pati].len();
+        let patlen = self.pats[pati].as_ref().len();
         let start = texti + 1 - patlen;
         Match {
             pati: pati,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,8 +199,8 @@ struct State<T> {
 impl<P: AsRef<[u8]>> AcAutomaton<P> {
     /// Create a new automaton from an iterator of patterns.
     ///
-    /// The patterns must be convertible to Unicode `String` values via the
-    /// `Into` trait.
+    /// The patterns must be convertible to bytes (`&[u8]`) via the `AsRef`
+    /// trait.
     pub fn new<I>(pats: I) -> AcAutomaton<P, Dense>
             where I: IntoIterator<Item=P> {
         AcAutomaton::with_transitions(pats)
@@ -212,8 +212,8 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
     ///
     /// This constructor allows one to choose the transition representation.
     ///
-    /// The patterns must be convertible to Unicode `String` values via the
-    /// `Into` trait.
+    /// The patterns must be convertible to bytes (`&[u8]`) via the `AsRef`
+    /// trait.
     pub fn with_transitions<I>(pats: I) -> AcAutomaton<P, T>
             where I: IntoIterator<Item=P> {
         AcAutomaton {
@@ -771,6 +771,20 @@ mod tests {
         assert_eq!(&aut_findos(&ns, hay), &matches);
         assert_eq!(&aut_findfo(&ns, hay), &matches);
         assert_eq!(&aut_findfos(&ns, hay), &matches);
+    }
+
+    #[test]
+    fn pattern_returns_original_type() {
+        let aut = AcAutomaton::new(vec!["apple", "maple"]);
+
+        // Explicitly given this type to assert that the thing returned
+        // from the function is our original type.
+        let pat: &str = aut.pattern(0);
+        assert_eq!(pat, "apple");
+
+        // Also check the return type of the `patterns` function.
+        let pats: &[&str] = aut.patterns();
+        assert_eq!(pats, &["apple", "maple"]);
     }
 
     // Quickcheck time.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,9 @@ const ROOT_STATE: u32 = 1;
 const DENSE_DEPTH_THRESHOLD: u32 = 3;
 
 /// An Aho-Corasick finite automaton.
+///
+/// The type parameter `P` is the type of the pattern that was used to
+/// construct this AcAutomaton.
 #[derive(Clone)]
 pub struct AcAutomaton<P, T=Dense> {
     pats: Vec<P>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ impl<T: Transitions> AcAutomaton<T> {
     }
 }
 
-impl<T: Transitions> Automaton for AcAutomaton<T> {
+impl<T: Transitions> Automaton<String> for AcAutomaton<T> {
     #[inline]
     fn next_state(&self, mut si: StateIdx, b: u8) -> StateIdx {
         loop {
@@ -287,7 +287,7 @@ impl<T: Transitions> Automaton for AcAutomaton<T> {
     }
 
     #[inline]
-    fn pattern(&self, i: usize) -> &str {
+    fn pattern(&self, i: usize) -> &String {
         &self.pats[i]
     }
 }


### PR DESCRIPTION
Allows using this crate with arbitrary patterns, so long as the patterns can be converted to a byte slice (i.e. `&[u8]`).

Closes #2