### PR TITLE
Allow searching in byte slices (and more).

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -19,6 +19,16 @@ fn bench_aut_no_match<P: AsRef<[u8]>, T: Transitions>(
     b.iter(|| assert!(aut.find(haystack).next().is_none()));
 }
 
+fn bench_box_aut_no_match<P: AsRef<[u8]>, T: Transitions>(
+    b: &mut Bencher,
+    aut: AcAutomaton<P, T>,
+    haystack: &str,
+) {
+    b.bytes = haystack.len() as u64;
+    let aut: &Automaton<P> = &aut;
+    b.iter(|| assert!(Automaton::find(&aut, haystack).next().is_none()));
+}
+
 fn bench_full_aut_no_match<P: AsRef<[u8]>, T: Transitions>(
     b: &mut Bencher,
     aut: AcAutomaton<P, T>,
@@ -58,8 +68,8 @@ use test::Bencher;
 
 use super::{
     HAYSTACK_RANDOM, haystack_same,
-    bench_aut_no_match, bench_full_aut_no_match,
-    bench_full_aut_overlapping_no_match,
+    bench_aut_no_match, bench_box_aut_no_match,
+    bench_full_aut_no_match, bench_full_aut_overlapping_no_match,
 };
 
 #[bench]
@@ -160,6 +170,7 @@ fn ac_ten_one_prefix_byte_random(b: &mut Bencher) {
 }}}
 
 aut_benches!(dense, AcAutomaton::new, bench_aut_no_match);
+aut_benches!(dense_boxed, AcAutomaton::new, bench_box_aut_no_match);
 aut_benches!(sparse, AcAutomaton::<&str, Sparse>::with_transitions,
              bench_aut_no_match);
 aut_benches!(full, AcAutomaton::new, bench_full_aut_no_match);

--- a/src/autiter.rs
+++ b/src/autiter.rs
@@ -53,13 +53,13 @@ pub trait Automaton<P>: Sized {
     }
 
     /// Returns an iterator of non-overlapping matches in `s`.
-    fn find<'a, 's>(
+    fn find<'a, 's, Q: ?Sized + AsRef<[u8]>>(
         &'a self,
-        s: &'s str,
+        s: &'s Q,
     ) -> Matches<'a, 's, P, Self> {
         Matches {
             aut: self,
-            text: s.as_bytes(),
+            text: s.as_ref(),
             texti: 0,
             si: ROOT_STATE,
             _m: PhantomData,
@@ -67,13 +67,13 @@ pub trait Automaton<P>: Sized {
     }
 
     /// Returns an iterator of overlapping matches in `s`.
-    fn find_overlapping<'a, 's>(
+    fn find_overlapping<'a, 's, Q: ?Sized + AsRef<[u8]>>(
         &'a self,
-        s: &'s str,
+        s: &'s Q,
     ) -> MatchesOverlapping<'a, 's, P, Self> {
         MatchesOverlapping {
             aut: self,
-            text: s.as_bytes(),
+            text: s.as_ref(),
             texti: 0,
             si: ROOT_STATE,
             outi: 0,


### PR DESCRIPTION
I'm not really sure that this is the right API. In particular, it makes Automaton no longer object-safe. Some other alternatives are:

- change the existing methods to take &[u8] instead of &str
- add new methods (bytes_find?) that take &[u8]