### PR TITLE
Bump memchr required version to compatible version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ doc = false
 bench = false
 
 [dependencies]
-memchr = "0.1"
+memchr = "0.1.9"
 
 [dev-dependencies]
 csv = "0.14"


### PR DESCRIPTION
aho-corasic requires `memchr::memchr2` and `memchr::memchr3`. These were not added until memchr reached version 0.1.9.

https://github.com/BurntSushi/rust-memchr/commit/a098d3d3a831b93f593fad9f81ad2956c128b0b0

https://github.com/BurntSushi/rust-memchr/commit/19d0452faa2b50ef2a75b4d2d0a8dce96b8b7a55