### PR TITLE
Remove documentation url from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "aho-corasick"
 version = "0.6.3"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Fast multiple substring searching with finite state machines."
-documentation = "http://burntsushi.net/rustdoc/aho_corasick/"
 homepage = "https://github.com/BurntSushi/aho-corasick"
 repository = "https://github.com/BurntSushi/aho-corasick"
 readme = "README.md"


### PR DESCRIPTION
The link in the README was updated just a commit ago, but the documentation link in the cargo metadata is still broken. I removed the link instead of updating it, since no such field means it will automatically link to docs.rs. That was obviously acceptable for the commit fixing the README link :)