### PR TITLE
Introduce `use_std` default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,12 @@ test = false
 doc = false
 bench = false
 
+[features]
+default = ["use_std"]
+use_std = ["memchr/use_std"]
+
 [dependencies]
-memchr = "2"
+memchr = { version = "2", default-features = false }
 
 [dev-dependencies]
 csv = "0.15"


### PR DESCRIPTION
aho-corasick depends on memchr which can optionally be compiled without
std. With the introduction of the `use_std` feature it is now possible
to compile aho-corasick with `default-features = false` which then uses
a memchr that doesn't depend on std.

This makes aho-corasick available on platforms like wasm which haven't
a libc implemented.