### PR TITLE
rollup + fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,4 @@ rust:
   - stable
   - beta
   - nightly
-script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-      cargo bench --verbose;
-    fi
+script: ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rust:
   - beta
   - nightly
 script: ci/script.sh
+branches:
+  only:
+    - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ name = "aho_corasick"
 
 [[bin]]
 name = "aho-corasick-dot"
+path = "src/main.rs"
 test = false
 doc = false
 bench = false
@@ -26,12 +27,13 @@ bench = false
 memchr = "2"
 
 [dev-dependencies]
-csv = "0.15"
-docopt = "0.7"
+csv = "1.0.0-beta.5"
+docopt = "0.8"
 memmap = "0.6"
 quickcheck = { version = "0.6", default-features = false }
 rand = "0.4"
-rustc-serialize = "0.3"
+serde = "1"
+serde_derive = "1"
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ memchr = "2"
 csv = "0.15"
 docopt = "0.7"
 memmap = "0.5"
-quickcheck = { version = "0.5", default-features = false }
-rand = "0.3"
+quickcheck = { version = "0.6", default-features = false }
+rand = "0.4"
 rustc-serialize = "0.3"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ memchr = "2"
 [dev-dependencies]
 csv = "0.15"
 docopt = "0.7"
-memmap = "0.5"
+memmap = "0.6"
 quickcheck = { version = "0.6", default-features = false }
 rand = "0.4"
 rustc-serialize = "0.3"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+cargo build --verbose
+cargo doc --verbose
+
+# If we're testing on an older version of Rust, then only check that we
+# can build the crate. This is because the dev dependencies might be updated
+# more frequently, and therefore might require a newer version of Rust.
+#
+# This isn't ideal. It's a compromise.
+if [ "$TRAVIS_RUST_VERSION" = "1.12.0" ]; then
+  exit
+fi
+
+cargo test --verbose
+if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+  cargo bench --verbose --no-run
+fi

--- a/examples/dict-search.rs
+++ b/examples/dict-search.rs
@@ -14,7 +14,7 @@ use std::process;
 
 use aho_corasick::{Automaton, AcAutomaton, Match};
 use docopt::Docopt;
-use memmap::{Mmap, Protection};
+use memmap::Mmap;
 
 static USAGE: &'static str = "
 Usage: dict-search [options] <input>
@@ -70,48 +70,37 @@ fn run(args: &Args) -> Result<(), Box<Error>> {
         return Ok(());
     }
 
+    let rdr = try!(File::open(&args.arg_input));
     if args.flag_full {
         let aut = aut.into_full();
         if args.flag_overlapping {
             if args.flag_count {
-                let mmap = Mmap::open_path(
-                    &args.arg_input, Protection::Read).unwrap();
-                let text = unsafe { mmap.as_slice() };
-                println!("{}", aut.find_overlapping(text).count());
+                let mmap = unsafe { try!(Mmap::map(&rdr)) };
+                println!("{}", aut.find_overlapping(&*mmap).count());
             } else {
-                let rdr = try!(File::open(&args.arg_input));
                 try!(write_matches(&aut, aut.stream_find_overlapping(rdr)));
             }
         } else {
             if args.flag_count {
-                let mmap = Mmap::open_path(
-                    &args.arg_input, Protection::Read).unwrap();
-                let text = unsafe { mmap.as_slice() };
-                println!("{}", aut.find(text).count());
+                let mmap = unsafe { try!(Mmap::map(&rdr)) };
+                println!("{}", aut.find(&*mmap).count());
             } else {
-                let rdr = try!(File::open(&args.arg_input));
                 try!(write_matches(&aut, aut.stream_find(rdr)));
             }
         }
     } else {
         if args.flag_overlapping {
             if args.flag_count {
-                let mmap = Mmap::open_path(
-                    &args.arg_input, Protection::Read).unwrap();
-                let text = unsafe { mmap.as_slice() };
-                println!("{}", aut.find_overlapping(text).count());
+                let mmap = unsafe { try!(Mmap::map(&rdr)) };
+                println!("{}", aut.find_overlapping(&*mmap).count());
             } else {
-                let rdr = try!(File::open(&args.arg_input));
                 try!(write_matches(&aut, aut.stream_find_overlapping(rdr)));
             }
         } else {
             if args.flag_count {
-                let mmap = Mmap::open_path(
-                    &args.arg_input, Protection::Read).unwrap();
-                let text = unsafe { mmap.as_slice() };
-                println!("{}", aut.find(text).count());
+                let mmap = unsafe { try!(Mmap::map(&rdr)) };
+                println!("{}", aut.find(&*mmap).count());
             } else {
-                let rdr = try!(File::open(&args.arg_input));
                 try!(write_matches(&aut, aut.stream_find(rdr)));
             }
         }


### PR DESCRIPTION
This rolls up #16 and #23 and fixes CI such that tests are no longer run on Rust 1.12 (but we still check compilation).