### PR TITLE
Add experimental feature flagged no_std support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*.swp
+.idea
 doc
 tags
 examples/ss10pusa.csv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ doc = false
 bench = false
 
 [dependencies]
-cfg-if = "0.1"
 memchr = { version = "2", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,11 @@ bench = false
 [dependencies]
 cfg-if = "0.1"
 memchr = { version = "2", default-features = false }
-# TODO - move to a non-specific-nightly-version-linked core io alternative
-core_io = { version = "0.1.20180307", optional = true, default-features = false, features = ["collections"] }
 
 [dev-dependencies]
 csv = "1.0.0-beta.5"
 docopt = "0.8"
+hashmap_core = "0.1"
 memmap = "0.6"
 quickcheck = { version = "0.6", default-features = false }
 serde = "1"
@@ -39,9 +38,9 @@ serde_derive = "1"
 
 [features]
 
-default = ["use_std"]
-use_std = ["memchr/use_std", "memchr/libc"]
-alloc = ["core_io"]
+default = ["std"]
+std = ["memchr/use_std", "memchr/libc"]
+alloc = []
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,16 @@ name = "aho_corasick"
 
 [[bin]]
 name = "aho-corasick-dot"
-path = "src/main.rs"
+path = "src/bin/aho-corasick-dot.rs"
 test = false
 doc = false
 bench = false
 
 [dependencies]
-memchr = "2"
+cfg-if = "0.1"
+memchr = { version = "2", default-features = false }
+# TODO - move to a non-specific-nightly-version-linked core io alternative
+core_io = { version = "0.1.20180307", optional = true, default-features = false, features = ["collections"] }
 
 [dev-dependencies]
 csv = "1.0.0-beta.5"
@@ -33,6 +36,12 @@ memmap = "0.6"
 quickcheck = { version = "0.6", default-features = false }
 serde = "1"
 serde_derive = "1"
+
+[features]
+
+default = ["use_std"]
+use_std = ["memchr/use_std", "memchr/libc"]
+alloc = ["core_io"]
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ memchr = { version = "2", default-features = false }
 [dev-dependencies]
 csv = "1.0.0-beta.5"
 docopt = "0.8"
-hashmap_core = "0.1"
 memmap = "0.6"
 quickcheck = { version = "0.6", default-features = false }
 serde = "1"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -17,4 +17,5 @@ fi
 cargo test --verbose
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
   cargo bench --verbose --no-run
+  cargo test --verbose --no-default-features --features "alloc"
 fi

--- a/examples/dict-search.rs
+++ b/examples/dict-search.rs
@@ -58,7 +58,12 @@ fn main() {
         }
     }
 }
+#[cfg(not(feature = "use_std"))]
+fn run(_: &Args) -> Result<(), Box<Error>> {
+   Err("The use_std feature is mandatory for the dict-search example to work".into())
+}
 
+#[cfg(feature = "use_std")]
 fn run(args: &Args) -> Result<(), Box<Error>> {
     let aut = try!(build_automaton(&args.flag_dict, args.flag_min_len));
     if args.flag_memory_usage {
@@ -110,6 +115,7 @@ fn run(args: &Args) -> Result<(), Box<Error>> {
     Ok(())
 }
 
+#[cfg(feature = "use_std")]
 fn write_matches<A, I>(aut: &A, it: I) -> Result<(), Box<Error>>
         where A: Automaton<String>, I: Iterator<Item=io::Result<Match>> {
     let mut wtr = csv::Writer::from_writer(io::stdout());
@@ -122,6 +128,7 @@ fn write_matches<A, I>(aut: &A, it: I) -> Result<(), Box<Error>>
     Ok(())
 }
 
+#[cfg(feature = "use_std")]
 fn build_automaton(
     dict_path: &str,
     min_len: usize,

--- a/examples/dict-search.rs
+++ b/examples/dict-search.rs
@@ -8,23 +8,19 @@ extern crate memmap;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate cfg_if;
-
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        use std::fs::File;
-        use std::io::BufRead;
-        use aho_corasick::{Automaton, AcAutomaton, Match};
-        use memmap::Mmap;
-    }
-}
+#[cfg(feature = "std")]
+use std::fs::File;
+#[cfg(feature = "std")]
+use std::io::BufRead;
+#[cfg(feature = "std")]
+use aho_corasick::{Automaton, AcAutomaton, Match};
+#[cfg(feature = "std")]
+use memmap::Mmap;
 use std::error::Error;
 use std::io::{self, Write};
 use std::process;
 
 use docopt::Docopt;
-
 static USAGE: &'static str = "
 Usage: dict-search [options] <input>
        dict-search --help

--- a/src/autiter.rs
+++ b/src/autiter.rs
@@ -1,11 +1,6 @@
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        use std::io::{self, BufRead};
-        use std::marker::PhantomData;
-    } else {
-        use core::marker::PhantomData;
-    }
-}
+#[cfg(feature = "std")]
+use core::io::{self, BufRead};
+use core::marker::PhantomData;
 
 use memchr::{memchr, memchr2, memchr3};
 

--- a/src/bin/aho-corasick-dot.rs
+++ b/src/bin/aho-corasick-dot.rs
@@ -1,11 +1,7 @@
-extern crate memchr;
-
+extern crate aho_corasick;
 use std::env;
 
-use lib::AcAutomaton;
-
-#[allow(dead_code)]
-mod lib;
+use aho_corasick::AcAutomaton;
 
 fn main() {
     let aut = AcAutomaton::new(env::args().skip(1));

--- a/src/full.rs
+++ b/src/full.rs
@@ -1,5 +1,14 @@
-use std::fmt;
-use std::mem;
+cfg_if! {
+    if #[cfg(feature = "use_std")] {
+        use std::vec::Vec;
+        use std::fmt;
+        use std::mem;
+    } else {
+        use alloc::vec::Vec;
+        use core::fmt;
+        use core::mem;
+    }
+}
 
 use super::{
     FAIL_STATE,

--- a/src/full.rs
+++ b/src/full.rs
@@ -1,5 +1,5 @@
 cfg_if! {
-    if #[cfg(feature = "use_std")] {
+    if #[cfg(feature = "std")] {
         use std::vec::Vec;
         use std::fmt;
         use std::mem;

--- a/src/full.rs
+++ b/src/full.rs
@@ -1,14 +1,9 @@
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        use std::vec::Vec;
-        use std::fmt;
-        use std::mem;
-    } else {
-        use alloc::vec::Vec;
-        use core::fmt;
-        use core::mem;
-    }
-}
+use core::fmt;
+use core::mem;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::vec::Vec;
 
 use super::{
     FAIL_STATE,


### PR DESCRIPTION
## What

The addition of feature flags, optional dependencies, and conditional compilation blocks to make aho-corasick work in either `std` or `no_std` + `alloc` environments.

The default-on "use_std" feature flag controls whether or not to compile in `#![no_std]` mode.

The alloc feature flag must be specified and the toolchain fixed to nightly-2018-03-07 for the no_std experimental mode to operate, due to the rather unpleasant pinning of `core_io` to particular versions.

## How

To build for std, nothing changes. `cargo build`

To build for no_std:

```
cargo build --no-default-features --features "alloc"
```

The test suites pass as normal in either mode, with the exception of one which relies on `HashSet`, which is not readily available in `alloc`, and one doc-test that makes use of the filesystem.

## Why

This PR is part of a thought experiment regarding what it will take to get `regex` and its dependencies to operate in `no_std` + `alloc` mode. In particular, it is aimed to prompt discussion about whether the general approach is acceptable and feel out options for the "io in no_std" situation.  The option used in this experiment thus far, https://github.com/jethrogb/rust-core_io , is thoroughly unofficial and, as mentioned, is both unfortunately version-pinned and somewhat annoying to interoperate.