### PR TITLE
perf: Speedup the automaton construction in debug builds

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -57,6 +57,23 @@ fn bench_naive_no_match<S>(b: &mut Bencher, needles: Vec<S>, haystack: &str)
     b.iter(|| assert!(!naive_find(&needles, haystack)));
 }
 
+#[bench]
+fn bench_construction(b: &mut Bencher) {
+    b.iter(|| {
+        AcAutomaton::new(test::black_box(
+            [
+                "ADL", "ADl", "AdL", "Adl", "BAK", "BAk", "BAK", "BaK", "Bak", "BaK", "HOL",
+                "HOl", "HoL", "Hol", "IRE", "IRe", "IrE", "Ire", "JOH", "JOh", "JoH", "Joh", "SHE",
+                "SHe", "ShE", "She", "WAT", "WAt", "WaT", "Wat", "aDL", "aDl", "adL", "adl", "bAK",
+                "bAk", "bAK", "baK", "bak", "baK", "hOL", "hOl", "hoL", "hol", "iRE", "iRe",
+                "irE", "ire", "jOH", "jOh", "joH", "joh", "sHE", "sHe", "shE", "she", "wAT", "wAt",
+                "waT", "wat", "ſHE", "ſHe", "ſhE", "ſhe",
+            ].iter()
+                .map(|x| *x),
+        ))
+    })
+}
+
 fn haystack_same(letter: char) -> String {
     iter::repeat(letter).take(10000).collect()
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -74,6 +74,23 @@ fn bench_construction(b: &mut Bencher) {
     })
 }
 
+#[bench]
+fn bench_full_construction(b: &mut Bencher) {
+    b.iter(|| {
+        AcAutomaton::new(test::black_box(
+            [
+                "ADL", "ADl", "AdL", "Adl", "BAK", "BAk", "BAK", "BaK", "Bak", "BaK", "HOL",
+                "HOl", "HoL", "Hol", "IRE", "IRe", "IrE", "Ire", "JOH", "JOh", "JoH", "Joh", "SHE",
+                "SHe", "ShE", "She", "WAT", "WAt", "WaT", "Wat", "aDL", "aDl", "adL", "adl", "bAK",
+                "bAk", "bAK", "baK", "bak", "baK", "hOL", "hOl", "hoL", "hol", "iRE", "iRe",
+                "irE", "ire", "jOH", "jOh", "joH", "joh", "sHE", "sHe", "shE", "she", "wAT", "wAt",
+                "waT", "wat", "ſHE", "ſHe", "ſhE", "ſhe",
+            ].iter()
+                .map(|x| *x),
+        )).into_full()
+    })
+}
+
 fn haystack_same(letter: char) -> String {
     iter::repeat(letter).take(10000).collect()
 }

--- a/src/full.rs
+++ b/src/full.rs
@@ -3,7 +3,7 @@ use std::mem;
 
 use super::{
     FAIL_STATE,
-    all_bytes,
+    AllBytesIter,
     StateIdx, AcAutomaton, Transitions, Match,
     usize_bytes, vec_bytes,
 };
@@ -120,7 +120,7 @@ impl<P: AsRef<[u8]>> Automaton<P> for FullAcAutomaton<P> {
 impl<P: AsRef<[u8]>> FullAcAutomaton<P> {
     fn build_matrix<T: Transitions>(&mut self, ac: &AcAutomaton<P, T>) {
         for (si, s) in ac.states.iter().enumerate().skip(1) {
-            for b in all_bytes() {
+            for b in AllBytesIter::new() {
                 self.set(si as StateIdx, b, ac.next_state(si as StateIdx, b));
             }
             for &pati in &s.out {

--- a/src/full.rs
+++ b/src/full.rs
@@ -3,6 +3,7 @@ use std::mem;
 
 use super::{
     FAIL_STATE,
+    all_bytes,
     StateIdx, AcAutomaton, Transitions, Match,
     usize_bytes, vec_bytes,
 };
@@ -119,7 +120,7 @@ impl<P: AsRef<[u8]>> Automaton<P> for FullAcAutomaton<P> {
 impl<P: AsRef<[u8]>> FullAcAutomaton<P> {
     fn build_matrix<T: Transitions>(&mut self, ac: &AcAutomaton<P, T>) {
         for (si, s) in ac.states.iter().enumerate().skip(1) {
-            for b in (0..256).map(|b| b as u8) {
+            for b in all_bytes() {
                 self.set(si as StateIdx, b, ac.next_state(si as StateIdx, b));
             }
             for &pati in &s.out {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,8 +386,18 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
                     }
                     let ufail = self.states[v as usize].goto(c);
                     self.states[u as usize].fail = ufail;
-                    let ufail_out = self.states[ufail as usize].out.clone();
-                    self.states[u as usize].out.extend(ufail_out);
+
+                    fn get_two<T>(xs: &mut [T], i: usize, j: usize) -> (&mut T, &mut T) {
+                        assert!(i != j && i < xs.len() && j < xs.len());
+                        unsafe {
+                            let x = &mut *(xs.get_unchecked_mut(i) as *mut T);
+                            let y = &mut *xs.get_unchecked_mut(j);
+                            (x, y)
+                        }
+                    }
+
+                    let (ufail_out, out) = get_two(&mut self.states, ufail as usize, u as usize);
+                    out.out.extend_from_slice(&ufail_out.out);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,13 +530,11 @@ impl Transitions for Sparse {
 
     #[inline]
     fn goto(&self, b: u8) -> StateIdx {
-        unsafe { *self.0.get_unchecked(b as usize) }
+        self.0[b as usize]
     }
 
     fn set_goto(&mut self, b: u8, si: StateIdx) {
-        unsafe {
-            *self.0.get_unchecked_mut(b as usize) = si;
-        }
+        self.0[b as usize] = si;
     }
 
     fn heap_bytes(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,9 +314,10 @@ impl Iterator for AllBytesIter {
     }
 }
 
-#[inline]
-fn all_bytes() -> AllBytesIter {
-    AllBytesIter(0)
+impl AllBytesIter {
+    fn new() -> AllBytesIter {
+        AllBytesIter(0)
+    }
 }
 
 // Below contains code for *building* the automaton. It's a reasonably faithful
@@ -345,7 +346,7 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
         }
         {
             let root_state = &mut self.states[ROOT_STATE as usize];
-            for c in all_bytes() {
+            for c in AllBytesIter::new() {
                 if root_state.goto(c) == FAIL_STATE {
                     root_state.set_goto(c, ROOT_STATE);
                 } else {
@@ -369,14 +370,14 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
         // Fill up the queue with all non-root transitions out of the root
         // node. Then proceed by breadth first traversal.
         let mut q = VecDeque::new();
-        for c in all_bytes() {
+        for c in AllBytesIter::new() {
             let si = self.states[ROOT_STATE as usize].goto(c);
             if si != ROOT_STATE {
                 q.push_front(si);
             }
         }
         while let Some(si) = q.pop_back() {
-            for c in all_bytes() {
+            for c in AllBytesIter::new() {
                 let u = self.states[si as usize].goto(c);
                 if u != FAIL_STATE {
                     q.push_front(u);
@@ -575,7 +576,7 @@ impl<T: Transitions> State<T> {
 
     fn goto_string(&self, root: bool) -> String {
         let mut goto = vec![];
-        for b in all_bytes() {
+        for b in AllBytesIter::new() {
             let si = self.goto(b);
             if (!root && si == FAIL_STATE) || (root && si == ROOT_STATE) {
                 continue;
@@ -616,7 +617,7 @@ digraph automaton {{
                 w!(out, "    {} [peripheries=2];\n", i);
             }
             w!(out, "    {} -> {} [style=dashed];\n", i, s.fail);
-            for b in all_bytes() {
+            for b in AllBytesIter::new() {
                 let si = s.goto(b);
                 if si == FAIL_STATE || (i == ROOT_STATE && si == ROOT_STATE) {
                     continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,8 +511,13 @@ impl Transitions for Dense {
 ///
 /// This can use enormous amounts of memory when there are many patterns,
 /// but matching is very fast.
-#[derive(Clone)]
 pub struct Sparse([StateIdx; 256]);
+
+impl Clone for Sparse {
+    fn clone(&self) -> Sparse {
+        Sparse(self.0)
+    }
+}
 
 impl fmt::Debug for Sparse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,14 +389,11 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
 
                     fn get_two<T>(xs: &mut [T], i: usize, j: usize) -> (&mut T, &mut T) {
                         if i < j {
-                            assert!(j < xs.len());
+                            let (before, after) = xs.split_at_mut(j);
+                            (&mut before[i], &mut after[0])
                         } else {
-                            assert!(i != j && i < xs.len());
-                        }
-                        unsafe {
-                            let x = &mut *(xs.get_unchecked_mut(i) as *mut T);
-                            let y = &mut *xs.get_unchecked_mut(j);
-                            (x, y)
+                            let (before, after) = xs.split_at_mut(i);
+                            (&mut after[0], &mut before[j])
                         }
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,11 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
                     self.states[u as usize].fail = ufail;
 
                     fn get_two<T>(xs: &mut [T], i: usize, j: usize) -> (&mut T, &mut T) {
-                        assert!(i != j && i < xs.len() && j < xs.len());
+                        if i < j {
+                            assert!(j < xs.len());
+                        } else {
+                            assert!(i != j && i < xs.len());
+                        }
                         unsafe {
                             let x = &mut *(xs.get_unchecked_mut(i) as *mut T);
                             let y = &mut *xs.get_unchecked_mut(j);


### PR DESCRIPTION
Bit of a weird one here but I have a few `RegexSet`s which together take ~8 seconds to construct at startup (in debug builds). After profiling I found that the construction of the automaton in this crate took a large part of the time so I took a stab at some low hanging improvements to reduce this time a bit.

The main commit that improved things is https://github.com/BurntSushi/aho-corasick/commit/30a56ad2b29fccb5c42810165dcc2991ed68df77 and the rest are just minor improvements so I think its fair if some of the other commits gets removed as they make things slightly more complex (release performance only increased by a few percent).

### Improvement for *debug* builds
```
 name                old ns/iter  new ns/iter  diff ns/iter   diff %  speedup 
 bench_construction  4,534,211    1,742,419      -2,791,792  -61.57%   x 2.60 
```

### Improvement for *release* builds
```
 name                     old ns/iter  new ns/iter  diff ns/iter  diff %  speedup
 bench_construction       126,839      125,764            -1,075  -0.85%   x 1.01
 bench_full_construction  400,366      378,340           -22,026  -5.50%   x 1.06
```