### PR TITLE
Improve performance of constructing automatons

### DIFF
--- a/src/full.rs
+++ b/src/full.rs
@@ -120,8 +120,9 @@ impl<P: AsRef<[u8]>> Automaton<P> for FullAcAutomaton<P> {
 impl<P: AsRef<[u8]>> FullAcAutomaton<P> {
     fn build_matrix<T: Transitions>(&mut self, ac: &AcAutomaton<P, T>) {
         for (si, s) in ac.states.iter().enumerate().skip(1) {
-            for b in AllBytesIter::new() {
-                self.set(si as StateIdx, b, ac.next_state(si as StateIdx, b));
+            for i in AllBytesIter::new() {
+                let goto = ac.memoized_next_state(self, si as StateIdx, i);
+                self.set(si as StateIdx, i, goto);
             }
             self.out[si].extend_from_slice(&s.out);
         }

--- a/src/full.rs
+++ b/src/full.rs
@@ -123,9 +123,7 @@ impl<P: AsRef<[u8]>> FullAcAutomaton<P> {
             for b in AllBytesIter::new() {
                 self.set(si as StateIdx, b, ac.next_state(si as StateIdx, b));
             }
-            for &pati in &s.out {
-                self.out[si].push(pati);
-            }
+            self.out[si].extend_from_slice(&s.out);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,30 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
               .sum::<usize>()
         + self.start_bytes.len()
     }
+
+    // The states of `full_automaton` should be set for all states < si
+    fn memoized_next_state(
+        &self,
+        full_automaton: &FullAcAutomaton<P>,
+        mut si: StateIdx,
+        b: u8,
+    ) -> StateIdx {
+        let current_si = si;
+        loop {
+            let state = &self.states[si as usize];
+            let maybe_si = state.goto(b);
+            if maybe_si != FAIL_STATE {
+                si = maybe_si;
+                break;
+            } else {
+                si = state.fail;
+                if si < current_si {
+                    return full_automaton.next_state(si, b);
+                }
+            }
+        }
+        si
+    }
 }
 
 impl<P: AsRef<[u8]>, T: Transitions> Automaton<P> for AcAutomaton<P, T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ impl Iterator for AllBytesIter {
     type Item = u8;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.0 <= 256 {
+        if self.0 < 256 {
             let b = self.0 as u8;
             self.0 += 1;
             Some(b)
@@ -644,7 +644,7 @@ mod tests {
 
     use quickcheck::{Arbitrary, Gen, quickcheck};
 
-    use super::{Automaton, AcAutomaton, Match};
+    use super::{AcAutomaton, Automaton, Match, AllBytesIter};
 
     fn aut_find<S>(xs: &[S], haystack: &str) -> Vec<Match>
             where S: Clone + AsRef<[u8]> {
@@ -967,5 +967,14 @@ mod tests {
             aset == nset
         }
         quickcheck(prop as fn(Vec<SmallAscii>, BiasAscii) -> bool);
+    }
+
+
+    #[test]
+    fn all_bytes_iter() {
+        let all_bytes = AllBytesIter::new().collect::<Vec<_>>();
+        assert_eq!(all_bytes[0], 0);
+        assert_eq!(all_bytes[255], 255);
+        assert!(AllBytesIter::new().enumerate().all(|(i, b)| b as usize == i));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,12 +253,13 @@ impl<P: AsRef<[u8]>, T: Transitions> Automaton<P> for AcAutomaton<P, T> {
     #[inline]
     fn next_state(&self, mut si: StateIdx, b: u8) -> StateIdx {
         loop {
-            let maybe_si = self.states[si as usize].goto(b);
+            let state = &self.states[si as usize];
+            let maybe_si = state.goto(b);
             if maybe_si != FAIL_STATE {
                 si = maybe_si;
                 break;
             } else {
-                si = self.states[si as usize].fail;
+                si = state.fail;
             }
         }
         si


### PR DESCRIPTION
Another PR in the vein of #31 but this time there are some nice performance increases in release mode (more so than in debug actually).

~~I took the liberty of running rustfmt as well (non-rustfmt changes here https://github.com/BurntSushi/aho-corasick/pull/32/files/5e0eb5e6bb714a211e85930358a06c8a4354cf72..f389029a1f674873fc0f7e36d75eb9a1c485a1d7).~~ (Noticed the rustfmting made a bit of a mess in benchmarks so I removed it).

```
# Release
 name                     old_release ns/iter  new ns/iter  diff ns/iter   diff %  speedup
 bench_construction       307,741              285,652           -22,089   -7.18%   x 1.08
 bench_full_construction  1,011,295            757,491          -253,804  -25.10%   x 1.34

# Debug
 name                     old ns/iter  new ns/iter  diff ns/iter   diff %  speedup
 bench_construction       1,501,990    1,451,315         -50,675   -3.37%   x 1.03
 bench_full_construction  6,012,099    4,998,499      -1,013,600  -16.86%   x 1.20
```