### PR TITLE
perf: Skip the first goto call in full construction (-35%)

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+# Newer libc's do not compile on rust 1.12
+if [ "$TRAVIS_RUST_VERSION" = "1.12.0" ]; then
+    cargo generate-lockfile
+    cargo update -p libc --precise "0.2.41"
+fi
+
 cargo build --verbose
 cargo doc --verbose
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,11 +402,9 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
         let mut transitions = Vec::new();
 
         while let Some(si) = q.pop_back() {
-            self.states[si as usize].for_each_transition(|c, u| {
-                if u != FAIL_STATE {
-                    transitions.push((c, u));
-                    q.push_front(u);
-                }
+            self.states[si as usize].for_each_ok_transition(|c, u| {
+                transitions.push((c, u));
+                q.push_front(u);
             });
 
             for (c, u) in transitions.drain(..) {
@@ -474,6 +472,12 @@ impl<T: Transitions> State<T> {
     {
         self.goto.for_each_transition(f)
     }
+
+    fn for_each_ok_transition<F>(&self, f: F)
+        where F: FnMut(u8, StateIdx)
+    {
+        self.goto.for_each_ok_transition(f)
+    }
 }
 
 /// An abstraction over state transition strategies.
@@ -500,6 +504,18 @@ pub trait Transitions {
         for b in AllBytesIter::new() {
             f(b, self.goto(b));
         }
+    }
+
+    /// Iterates over each non-fail state
+    fn for_each_ok_transition<F>(&self, mut f: F)
+    where
+        F: FnMut(u8, StateIdx),
+    {
+        self.for_each_transition(|b, si| {
+            if si != FAIL_STATE {
+                f(b, si);
+            }
+        });
     }
 }
 
@@ -572,6 +588,17 @@ impl Transitions for Dense {
                     f(b as u8, FAIL_STATE);
                     b += 1;
                 }
+            }
+        }
+    }
+    fn for_each_ok_transition<F>(&self, mut f: F)
+    where
+        F: FnMut(u8, StateIdx),
+    {
+        match self.0 {
+            DenseChoice::Sparse(ref m) => m.for_each_ok_transition(f),
+            DenseChoice::Dense(ref m) => for &(b, si) in m {
+                f(b, si)
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,37 +393,47 @@ impl<P: AsRef<[u8]>, T: Transitions> AcAutomaton<P, T> {
         // Fill up the queue with all non-root transitions out of the root
         // node. Then proceed by breadth first traversal.
         let mut q = VecDeque::new();
-        for c in AllBytesIter::new() {
-            let si = self.states[ROOT_STATE as usize].goto(c);
+        self.states[ROOT_STATE as usize].for_each_transition(|_, si| {
             if si != ROOT_STATE {
                 q.push_front(si);
             }
-        }
+        });
+
+        let mut transitions = Vec::new();
+
         while let Some(si) = q.pop_back() {
-            for c in AllBytesIter::new() {
-                let u = self.states[si as usize].goto(c);
+            self.states[si as usize].for_each_transition(|c, u| {
                 if u != FAIL_STATE {
+                    transitions.push((c, u));
                     q.push_front(u);
-                    let mut v = self.states[si as usize].fail;
-                    while self.states[v as usize].goto(c) == FAIL_STATE {
-                        v = self.states[v as usize].fail;
-                    }
-                    let ufail = self.states[v as usize].goto(c);
-                    self.states[u as usize].fail = ufail;
-
-                    fn get_two<T>(xs: &mut [T], i: usize, j: usize) -> (&mut T, &mut T) {
-                        if i < j {
-                            let (before, after) = xs.split_at_mut(j);
-                            (&mut before[i], &mut after[0])
-                        } else {
-                            let (before, after) = xs.split_at_mut(i);
-                            (&mut after[0], &mut before[j])
-                        }
-                    }
-
-                    let (ufail_out, out) = get_two(&mut self.states, ufail as usize, u as usize);
-                    out.out.extend_from_slice(&ufail_out.out);
                 }
+            });
+
+            for (c, u) in transitions.drain(..) {
+                let mut v = self.states[si as usize].fail;
+                loop {
+                    let state = &self.states[v as usize];
+                    if state.goto(c) == FAIL_STATE {
+                        v = state.fail;
+                    } else {
+                        break;
+                    }
+                }
+                let ufail = self.states[v as usize].goto(c);
+                self.states[u as usize].fail = ufail;
+
+                fn get_two<T>(xs: &mut [T], i: usize, j: usize) -> (&mut T, &mut T) {
+                    if i < j {
+                        let (before, after) = xs.split_at_mut(j);
+                        (&mut before[i], &mut after[0])
+                    } else {
+                        let (before, after) = xs.split_at_mut(i);
+                        (&mut after[0], &mut before[j])
+                    }
+                }
+
+                let (ufail_out, out) = get_two(&mut self.states, ufail as usize, u as usize);
+                out.out.extend_from_slice(&ufail_out.out);
             }
         }
         self


### PR DESCRIPTION
* perf: Skip the first goto call in full construction (-35%)

This is probably less significant when larger number of needles are used
but should still be a decent speed improvement.

```
 name                     old ns/iter  new ns/iter  diff ns/iter   diff %  speedup
 bench_construction       131,148      122,956            -8,192   -6.25%   x 1.07
 bench_full_construction  309,493      200,595          -108,898  -35.19%   x 1.54
```

* perf: Use for_each_transition in AcAutomaton::fill (-84%)

```
 name                     old ns/iter  new ns/iter  diff ns/iter   diff %  speedup
 bench_construction       167,415      25,804           -141,611  -84.59%   x 6.49
 bench_full_construction  275,170      133,253          -141,917  -51.57%   x 2.07
```

(The two benchmarks were done on different computers)