### PR TITLE
Expand quickcheck test suite

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -746,7 +746,7 @@ mod tests {
     use quickcheck::{Arbitrary, Gen, quickcheck};
     use rand::Rng;
 
-    use super::{AcAutomaton, Automaton, Match, AllBytesIter};
+    use super::{AcAutomaton, Automaton, Match, AllBytesIter, Sparse};
 
     fn aut_find<S>(xs: &[S], haystack: &str) -> Vec<Match>
             where S: Clone + AsRef<[u8]> {
@@ -797,6 +797,21 @@ mod tests {
         AcAutomaton::new(xs.to_vec())
             .into_full()
             .stream_find_overlapping(cur).map(|r| r.unwrap()).collect()
+    }
+
+    fn aut_findso<S>(xs: &[S], haystack: &str) -> Vec<Match>
+            where S: Clone + AsRef<[u8]> {
+        AcAutomaton::<_, Sparse>::with_transitions(xs.to_vec())
+            .find_overlapping(haystack)
+            .collect()
+    }
+
+    fn aut_findsfo<S>(xs: &[S], haystack: &str) -> Vec<Match>
+            where S: Clone + AsRef<[u8]> {
+        AcAutomaton::<_, Sparse>::with_transitions(xs.to_vec())
+            .into_full()
+            .find_overlapping(haystack)
+            .collect()
     }
 
     #[test]
@@ -916,6 +931,8 @@ mod tests {
         assert_eq!(&aut_findos(&ns, hay), &matches);
         assert_eq!(&aut_findfo(&ns, hay), &matches);
         assert_eq!(&aut_findfos(&ns, hay), &matches);
+        assert_eq!(&aut_findso(&ns, hay), &matches);
+        assert_eq!(&aut_findsfo(&ns, hay), &matches);
     }
 
     #[test]
@@ -927,6 +944,8 @@ mod tests {
         assert_eq!(&aut_findos(&ns, hay), &matches);
         assert_eq!(&aut_findfo(&ns, hay), &matches);
         assert_eq!(&aut_findfos(&ns, hay), &matches);
+        assert_eq!(&aut_findso(&ns, hay), &matches);
+        assert_eq!(&aut_findsfo(&ns, hay), &matches);
     }
 
     #[test]
@@ -945,6 +964,8 @@ mod tests {
         assert_eq!(&aut_findos(&ns, hay), &matches);
         assert_eq!(&aut_findfo(&ns, hay), &matches);
         assert_eq!(&aut_findfos(&ns, hay), &matches);
+        assert_eq!(&aut_findso(&ns, hay), &matches);
+        assert_eq!(&aut_findsfo(&ns, hay), &matches);
     }
 
     #[test]
@@ -963,6 +984,8 @@ mod tests {
         assert_eq!(&aut_findos(&ns, hay), &matches);
         assert_eq!(&aut_findfo(&ns, hay), &matches);
         assert_eq!(&aut_findfos(&ns, hay), &matches);
+        assert_eq!(&aut_findso(&ns, hay), &matches);
+        assert_eq!(&aut_findsfo(&ns, hay), &matches);
     }
 
     #[test]
@@ -1072,9 +1095,33 @@ mod tests {
     }
 
     #[test]
-    fn qc_ac_equals_naive() {
+    fn qc_ac_dense_equals_naive() {
         let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
             prop_ac_equals_naive(needles, haystack, aut_findo)
+        };
+        quickcheck(prop);
+    }
+
+    #[test]
+    fn qc_ac_dense_full_equals_naive() {
+        let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
+            prop_ac_equals_naive(needles, haystack, aut_findfo)
+        };
+        quickcheck(prop);
+    }
+
+    #[test]
+    fn qc_ac_sparse_equals_naive() {
+        let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
+            prop_ac_equals_naive(needles, haystack, aut_findso)
+        };
+        quickcheck(prop);
+    }
+
+    #[test]
+    fn qc_ac_sparse_full_equals_naive() {
+        let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
+            prop_ac_equals_naive(needles, haystack, aut_findsfo)
         };
         quickcheck(prop);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -743,7 +743,7 @@ mod tests {
     use std::collections::HashSet;
     use std::io;
 
-    use quickcheck::{Arbitrary, Gen, quickcheck};
+    use quickcheck::{Arbitrary, Gen, QuickCheck};
     use rand::Rng;
 
     use super::{AcAutomaton, Automaton, Match, AllBytesIter, Sparse};
@@ -1012,7 +1012,8 @@ mod tests {
     impl Arbitrary for SmallAscii {
         fn arbitrary<G: Gen>(g: &mut G) -> SmallAscii {
             use std::char::from_u32;
-            SmallAscii((0..2)
+            let len = g.gen_range(0, 10);
+            SmallAscii((0..len)
                        .map(|_| from_u32(g.gen_range(97, 123)).unwrap())
                        .collect())
         }
@@ -1099,7 +1100,7 @@ mod tests {
         let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
             prop_ac_equals_naive(needles, haystack, aut_findo)
         };
-        quickcheck(prop);
+        QuickCheck::new().tests(400).quickcheck(prop);
     }
 
     #[test]
@@ -1107,7 +1108,7 @@ mod tests {
         let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
             prop_ac_equals_naive(needles, haystack, aut_findfo)
         };
-        quickcheck(prop);
+        QuickCheck::new().tests(400).quickcheck(prop);
     }
 
     #[test]
@@ -1115,7 +1116,7 @@ mod tests {
         let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
             prop_ac_equals_naive(needles, haystack, aut_findso)
         };
-        quickcheck(prop);
+        QuickCheck::new().tests(400).quickcheck(prop);
     }
 
     #[test]
@@ -1123,7 +1124,7 @@ mod tests {
         let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
             prop_ac_equals_naive(needles, haystack, aut_findsfo)
         };
-        quickcheck(prop);
+        QuickCheck::new().tests(400).quickcheck(prop);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1057,20 +1057,27 @@ mod tests {
         matches
     }
 
-    #[test]
-    fn qc_ac_equals_naive() {
-        fn prop(needles: Vec<SmallAscii>, haystack: BiasAscii) -> bool {
-            let aut_matches = aut_findo(&needles, &haystack.0);
-            let naive_matches = naive_find(&needles, &haystack.0);
-            // Ordering isn't always the same. I don't think we care, so do
-            // an unordered comparison.
-            let aset: HashSet<Match> = aut_matches.iter().cloned().collect();
-            let nset: HashSet<Match> = naive_matches.iter().cloned().collect();
-            aset == nset
-        }
-        quickcheck(prop as fn(Vec<SmallAscii>, BiasAscii) -> bool);
+    fn prop_ac_equals_naive<F>(
+        needles: Vec<SmallAscii>,
+        haystack: BiasAscii,
+        ac_find: F
+    ) -> bool where F: Fn(&[SmallAscii], &str) -> Vec<Match> {
+        let aut_matches = ac_find(&needles, &haystack.0);
+        let naive_matches = naive_find(&needles, &haystack.0);
+        // Ordering isn't always the same. I don't think we care, so do
+        // an unordered comparison.
+        let aset: HashSet<Match> = aut_matches.iter().cloned().collect();
+        let nset: HashSet<Match> = naive_matches.iter().cloned().collect();
+        aset == nset
     }
 
+    #[test]
+    fn qc_ac_equals_naive() {
+        let prop: fn(Vec<SmallAscii>, BiasAscii) -> bool = |needles, haystack| {
+            prop_ac_equals_naive(needles, haystack, aut_findo)
+        };
+        quickcheck(prop);
+    }
 
     #[test]
     fn all_bytes_iter() {


### PR DESCRIPTION
* Test the sparse automation, in addition to the dense one.
* Run the quickcheck test on the sparse and dense automaton, and for full and non-full. Previously only the non-full automaton was tested.
* Bump the number of iterations and the size of the test data, so the test suite now catches #35.