### PR TITLE
Automatically check if README.md examples are working when running "cargo test"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ std = ["memchr/use_std"]
 [dependencies]
 memchr = { version = "2.2.0", default-features = false }
 
+[dev-dependencies]
+doc-comment = "0.3.1"
+
 [profile.release]
 debug = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,12 @@ performance in some cases. For that reason, prefilters can be disabled via
 compile_error!("`std` feature is currently required to build this crate");
 
 extern crate memchr;
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
 
 pub use ahocorasick::{
     AhoCorasick, AhoCorasickBuilder, MatchKind,


### PR DESCRIPTION
Since rustdoc nightly now provides "cfg(test)" when running on test mode, we can now use this macro on test mode only to check if README.md examples are working as expected.