### PR TITLE
remove several uses of unsafe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target
 scratch*
 bench_large/huge
 BREADCRUMBS
+/tmp
+/aho-corasick-debug/Cargo.lock

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@ This document describes the internal design of this crate, which is an object
 lesson in what happens when you take a fairly simple old algorithm like
 Aho-Corasick and make it fast and production ready.
 
-The target audience of this crate is Rust programmers that have some
+The target audience of this document is Rust programmers that have some
 familiarity with string searching, however, one does not need to know the
 Aho-Corasick algorithm in order to read this (it is explained below). One
 should, however, know what a trie is. (If you don't, go read its Wikipedia
@@ -13,7 +13,7 @@ own, Aho-Corasick isn't that complicated. The complex pieces come from the
 different variants of Aho-Corasick implemented in this crate. Specifically,
 they are:
 
-* Aho-Corasick as an NFA, using dense transitions near root with sparse
+* Aho-Corasick as an NFA, using dense transitions near the root with sparse
   transitions elsewhere.
 * Aho-Corasick as a DFA. (An NFA is slower to search, but cheaper to construct
   and uses less memory.)
@@ -74,7 +74,7 @@ one is Aho-Corasick. It's a common solution because it's not too hard to
 implement, scales quite well even when searching for thousands of patterns and
 is generally pretty fast. Aho-Corasick does well here because, regardless of
 the number of patterns you're searching for, it always visits each byte in the
-haystack exactly ocne. This means, generally speaking, adding more patterns to
+haystack exactly once. This means, generally speaking, adding more patterns to
 an Aho-Corasick automaton does not make it slower. (Strictly speaking, however,
 this is not true, since a larger automaton will make less effective use of the
 CPU's cache.)
@@ -277,12 +277,12 @@ there are a small number of patterns.
 
 # More DFA tricks
 
-As described in the previous section, one of the downsides of using a DFA is
-that is uses more memory and can take longer to builder. One small way of
-mitigating these concerns is to map the alphabet used by the automaton into a
-smaller space. Typically, the alphabet of a DFA has 256 elements in it: one
-element for each possible value that fits into a byte. However, in many cases,
-one does not need the full alphabet. For example, if all patterns in an
+As described in the previous section, one of the downsides of using a DFA
+is that is uses more memory and can take longer to build. One small way of
+mitigating these concerns is to map the alphabet used by the automaton into
+a smaller space. Typically, the alphabet of a DFA has 256 elements in it:
+one element for each possible value that fits into a byte. However, in many
+cases, one does not need the full alphabet. For example, if all patterns in an
 Aho-Corasick automaton are ASCII letters, then this only uses up 52 distinct
 bytes. As far as the automaton is concerned, the rest of the 204 bytes are
 indistinguishable from one another: they will never disrciminate between a

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -17,5 +17,5 @@ harness = false
 path = "src/bench.rs"
 
 [dependencies]
-criterion = "0.2"
+criterion = "0.3"
 aho-corasick = { version = "*", path = ".." }

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -161,7 +161,7 @@ fn define(
     corpus: &[u8],
     bench: impl FnMut(&mut Bencher) + 'static,
 ) {
-    let tput = Throughput::Bytes(corpus.len() as u32);
+    let tput = Throughput::Bytes(corpus.len() as u64);
     let benchmark = Benchmark::new(bench_name, bench)
         .throughput(tput)
         .sample_size(30)
@@ -179,7 +179,7 @@ fn define_long(
     corpus: &[u8],
     bench: impl FnMut(&mut Bencher) + 'static,
 ) {
-    let tput = Throughput::Bytes(corpus.len() as u32);
+    let tput = Throughput::Bytes(corpus.len() as u64);
     let benchmark = Benchmark::new(bench_name, bench)
         .throughput(tput)
         .sample_size(20)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -117,6 +117,8 @@ impl Buffer {
             // SAFETY: A buffer contains Copy data, so there's no problem
             // moving it around. Safety also depends on our indices being in
             // bounds, which they always should be, given the assert above.
+            //
+            // TODO: Switch to [T]::copy_within once our MSRV is high enough.
             ptr::copy(
                 self.buf[roll_start..].as_ptr(),
                 self.buf.as_mut_ptr(),

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -36,7 +36,7 @@ impl ByteClasses {
     pub fn get(&self, byte: u8) -> u8 {
         // SAFETY: This is safe because all dense transitions have
         // exactly 256 elements, so all u8 values are valid indices.
-        unsafe { *self.0.get_unchecked(byte as usize) }
+        self.0[byte as usize]
     }
 
     /// Return the total number of elements in the alphabet represented by

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -189,9 +189,9 @@ impl<S: StateID> Automaton for Standard<S> {
         self.repr().match_count(id)
     }
 
-    unsafe fn next_state_unchecked(&self, current: S, input: u8) -> S {
+    fn next_state(&self, current: S, input: u8) -> S {
         let o = current.to_usize() * 256 + input as usize;
-        *self.repr().trans.get_unchecked(o)
+        self.repr().trans[o]
     }
 }
 
@@ -248,11 +248,11 @@ impl<S: StateID> Automaton for ByteClass<S> {
         self.repr().match_count(id)
     }
 
-    unsafe fn next_state_unchecked(&self, current: S, input: u8) -> S {
+    fn next_state(&self, current: S, input: u8) -> S {
         let alphabet_len = self.repr().byte_classes.alphabet_len();
         let input = self.repr().byte_classes.get(input);
         let o = current.to_usize() * alphabet_len + input as usize;
-        *self.repr().trans.get_unchecked(o)
+        self.repr().trans[o]
     }
 }
 
@@ -317,9 +317,9 @@ impl<S: StateID> Automaton for Premultiplied<S> {
         self.repr().matches[o].len()
     }
 
-    unsafe fn next_state_unchecked(&self, current: S, input: u8) -> S {
+    fn next_state(&self, current: S, input: u8) -> S {
         let o = current.to_usize() + input as usize;
-        *self.repr().trans.get_unchecked(o)
+        self.repr().trans[o]
     }
 }
 
@@ -384,10 +384,10 @@ impl<S: StateID> Automaton for PremultipliedByteClass<S> {
         self.repr().matches[o].len()
     }
 
-    unsafe fn next_state_unchecked(&self, current: S, input: u8) -> S {
+    fn next_state(&self, current: S, input: u8) -> S {
         let input = self.repr().byte_classes.get(input);
         let o = current.to_usize() + input as usize;
-        *self.repr().trans.get_unchecked(o)
+        self.repr().trans[o]
     }
 }
 

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -262,14 +262,14 @@ impl<S: StateID> Automaton for NFA<S> {
         self.states[id.to_usize()].matches.len()
     }
 
-    unsafe fn next_state_unchecked(&self, mut current: S, input: u8) -> S {
+    fn next_state(&self, mut current: S, input: u8) -> S {
         // This terminates since:
         //
         // 1. `State.fail` never points to fail_id().
         // 2. All `State.fail` values point to a state closer to `start`.
         // 3. The start state has no transitions to fail_id().
         loop {
-            let state = self.states.get_unchecked(current.to_usize());
+            let state = &self.states[current.to_usize()];
             let next = state.next_state(input);
             if next != fail_id() {
                 return next;
@@ -335,9 +335,9 @@ impl<S: StateID> State<S> {
 
 /// Represents the transitions for a single dense state.
 ///
-/// The primary purpose here is to encapsulate unchecked index access. Namely,
-/// since a dense representation always contains 256 elements, all values of
-/// `u8` are valid indices.
+/// The primary purpose here is to encapsulate index access. Namely, since a
+/// dense representation always contains 256 elements, all values of `u8` are
+/// valid indices.
 #[derive(Clone, Debug)]
 struct Dense<S>(Vec<S>);
 
@@ -362,7 +362,7 @@ impl<S> Index<u8> for Dense<S> {
     fn index(&self, i: u8) -> &S {
         // SAFETY: This is safe because all dense transitions have
         // exactly 256 elements, so all u8 values are valid indices.
-        unsafe { self.0.get_unchecked(i as usize) }
+        &self.0[i as usize]
     }
 }
 
@@ -371,7 +371,7 @@ impl<S> IndexMut<u8> for Dense<S> {
     fn index_mut(&mut self, i: u8) -> &mut S {
         // SAFETY: This is safe because all dense transitions have
         // exactly 256 elements, so all u8 values are valid indices.
-        unsafe { self.0.get_unchecked_mut(i as usize) }
+        &mut self.0[i as usize]
     }
 }
 

--- a/src/state_id.rs
+++ b/src/state_id.rs
@@ -69,18 +69,7 @@ mod private {
 /// other type. In particular, this crate provides implementations for `u8`,
 /// `u16`, `u32`, `u64` and `usize`. (`u32` and `u64` are only provided for
 /// targets that can represent all corresponding values in a `usize`.)
-///
-/// # Safety
-///
-/// This trait is unsafe because the correctness of its implementations may be
-/// relied upon by other unsafe code. For example, one possible way to
-/// implement this trait incorrectly would be to return a maximum identifier
-/// in `max_id` that is greater than the real maximum identifier. This will
-/// likely result in wrap-on-overflow semantics in release mode, which can in
-/// turn produce incorrect state identifiers. Those state identifiers may then
-/// in turn access out-of-bounds memory in an automaton's search routine, where
-/// bounds checks are explicitly elided for performance reasons.
-pub unsafe trait StateID:
+pub trait StateID:
     private::Sealed
     + Clone
     + Copy
@@ -111,11 +100,11 @@ pub unsafe trait StateID:
     /// Return the maximum state identifier supported by this representation.
     ///
     /// Implementors must return a correct bound. Doing otherwise may result
-    /// in memory unsafety.
+    /// in unspecified behavior (but will not violate memory safety).
     fn max_id() -> usize;
 }
 
-unsafe impl StateID for usize {
+impl StateID for usize {
     #[inline]
     fn from_usize(n: usize) -> usize {
         n
@@ -132,7 +121,7 @@ unsafe impl StateID for usize {
     }
 }
 
-unsafe impl StateID for u8 {
+impl StateID for u8 {
     #[inline]
     fn from_usize(n: usize) -> u8 {
         n as u8
@@ -149,7 +138,7 @@ unsafe impl StateID for u8 {
     }
 }
 
-unsafe impl StateID for u16 {
+impl StateID for u16 {
     #[inline]
     fn from_usize(n: usize) -> u16 {
         n as u16
@@ -167,7 +156,7 @@ unsafe impl StateID for u16 {
 }
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
-unsafe impl StateID for u32 {
+impl StateID for u32 {
     #[inline]
     fn from_usize(n: usize) -> u32 {
         n as u32
@@ -185,7 +174,7 @@ unsafe impl StateID for u32 {
 }
 
 #[cfg(target_pointer_width = "64")]
-unsafe impl StateID for u64 {
+impl StateID for u64 {
     #[inline]
     fn from_usize(n: usize) -> u64 {
         n as u64


### PR DESCRIPTION
This PR principally removes several uses of unsafe that were used to elide bounds checks.

When I first added these `unsafe` uses, I did benchmark them and I thought they had come with an improvement. However, I did not record my results anywhere.

I spent some time re-benchmarking things, and it looks like eliding bounds checks (to my surprise) does not only not make things faster, but it actually makes them _slower_ by a small amount. Specifically, I have two ways of benchmarking code in this crate:

* A large set of micro-benchmarks.
* A CLI utility, aho-corasick-debug, that permits ad hoc benchmarking beyond micro-benchmarks.

With respect to micro-benchmarks, the only non-noisy difference I could detect between having bounds checks and eliding bounds checks was in the benchmarks on randomized corpora. In that case, bounds checks were 20-50% slower overall. This makes sense since random text is where a branch predictor will be at its worst.

However, the CLI utility demonstrated a pretty consistent performance _improvement_ when bounds checks were added. (Specifically, the bounds on the haystack access and the transition table access.) It's pretty small, but I was able to reproduce it on two different machines consistently (an i5 and an i7):

```
    $ cat input
    Sherlock Holmes
    John Watson
    Professor Moriarty
    Irene Adler
    Mary Watson
    
    $ aho-corasick-debug-safer input OpenSubtitles2018.raw.sample.en --kind leftmost-first --dfa
    pattern read time: 32.824µs
    automaton build time: 444.687µs
    automaton heap usage: 72392 bytes
    match count: 639
    count time: 1.809961702s
    
    $ aho-corasick-debug-master input OpenSubtitles2018.raw.sample.en --kind leftmost-first --dfa
    pattern read time: 31.425µs
    automaton build time: 317.434µs
    automaton heap usage: 72392 bytes
    match count: 639
    count time: 2.059157705s
```

This performance difference was present even when increasing the automaton size drastically (e.g., larger than my CPU's cache).

This result has me stumped, but it's hard to argue with the result. My mental model cannot quite explain why the presence of bounds checks makes the code faster. My _suspicion_ is that there is something about the codegen that is not quite optimal even though it looks reasonable to me.

In removing many uses of `unsafe`, we also document our tracks better, so that if we need to reverse this decision, it will be easy to re-trace my steps.

Outside of the SIMD code, there is still one `unsafe` use remaining, which is in the buffer handling code. Once our MSRV reaches Rust 1.37+, then we can remove that in favor of [`[T]::copy_within`](https://doc.rust-lang.org/std/primitive.slice.html#method.copy_within).

The SIMD code still has `unsafe` littered everywhere, but I don't see a good path to removing that. In theory, a platform independent API could help here some, but I fear Teddy is too "clever" for that.