### PR TITLE
prefilter: fix rare byte prefilter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,6 @@ jobs:
         toolchain: stable
         profile: minimal
         components: rustfmt
-    - name: Install rustfmt
-      run: rustup component add rustfmt
     - name: Check formatting
       run: |
         cargo fmt --all -- --check

--- a/src/prefilter.rs
+++ b/src/prefilter.rs
@@ -371,8 +371,14 @@ struct RareBytesBuilder {
     /// Whether this prefilter should account for ASCII case insensitivity or
     /// not.
     ascii_case_insensitive: bool,
-    /// A set of byte offsets associated with detected rare bytes. An entry is
-    /// only set if a rare byte is detected in a pattern.
+    /// A set of rare bytes, indexed by byte value.
+    rare_set: ByteSet,
+    /// A set of byte offsets associated with bytes in a pattern. An entry
+    /// corresponds to a particular bytes (its index) and is only non-zero if
+    /// the byte occurred at an offset greater than 0 in at least one pattern.
+    ///
+    /// If a byte's offset is not representable in 8 bits, then the rare bytes
+    /// prefilter becomes inert.
     byte_offsets: RareByteOffsets,
     /// Whether this is available as a prefilter or not. This can be set to
     /// false during construction if a condition is seen that invalidates the
@@ -385,11 +391,43 @@ struct RareBytesBuilder {
     rank_sum: u16,
 }
 
-/// A set of rare byte offsets, keyed by byte.
+/// A set of bytes.
+#[derive(Clone, Copy)]
+struct ByteSet([bool; 256]);
+
+impl ByteSet {
+    fn empty() -> ByteSet {
+        ByteSet([false; 256])
+    }
+
+    fn insert(&mut self, b: u8) -> bool {
+        let new = !self.contains(b);
+        self.0[b as usize] = true;
+        new
+    }
+
+    fn contains(&self, b: u8) -> bool {
+        self.0[b as usize]
+    }
+}
+
+impl fmt::Debug for ByteSet {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut bytes = vec![];
+        for b in 0..=255 {
+            if self.contains(b) {
+                bytes.push(b);
+            }
+        }
+        f.debug_struct("ByteSet").field("set", &bytes).finish()
+    }
+}
+
+/// A set of byte offsets, keyed by byte.
 #[derive(Clone, Copy)]
 struct RareByteOffsets {
-    /// When an item in this set has an offset of u8::MAX (255), then it is
-    /// considered unset.
+    /// Each entry corresponds to the maximum offset of the corresponding
+    /// byte across all patterns seen.
     set: [RareByteOffset; 256],
 }
 
@@ -403,21 +441,9 @@ impl RareByteOffsets {
     /// greater than the existing offset, then it overwrites the previous
     /// value and returns false. If there is no previous value set, then this
     /// sets it and returns true.
-    ///
-    /// The given offset must be active, otherwise this panics.
-    pub fn apply(&mut self, byte: u8, off: RareByteOffset) -> bool {
-        assert!(off.is_active());
-
-        let existing = &mut self.set[byte as usize];
-        if !existing.is_active() {
-            *existing = off;
-            true
-        } else {
-            if existing.max < off.max {
-                *existing = off;
-            }
-            false
-        }
+    pub fn set(&mut self, byte: u8, off: RareByteOffset) {
+        self.set[byte as usize].max =
+            cmp::max(self.set[byte as usize].max, off.max);
     }
 }
 
@@ -425,7 +451,7 @@ impl fmt::Debug for RareByteOffsets {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut offsets = vec![];
         for off in self.set.iter() {
-            if off.is_active() {
+            if off.max > 0 {
                 offsets.push(off);
             }
         }
@@ -448,33 +474,27 @@ struct RareByteOffset {
     /// ineffective when it is asked to start scanning from a position that it
     /// has already scanned past.
     ///
-    /// N.B. The maximum value for this is 254. A value of 255 indicates that
-    /// this is unused. If a rare byte is found at an offset of 255 or greater,
-    /// then the rare-byte prefilter is disabled for simplicity.
+    /// Using a `u8` here means that if we ever see a pattern that's longer
+    /// than 255 bytes, then the entire rare byte prefilter is disabled.
     max: u8,
 }
 
 impl Default for RareByteOffset {
     fn default() -> RareByteOffset {
-        RareByteOffset { max: u8::MAX }
+        RareByteOffset { max: 0 }
     }
 }
 
 impl RareByteOffset {
     /// Create a new rare byte offset. If the given offset is too big, then
-    /// an inactive `RareByteOffset` is returned.
-    fn new(max: usize) -> RareByteOffset {
-        if max > (u8::MAX - 1) as usize {
-            RareByteOffset::default()
+    /// None is returned. In that case, callers should render the rare bytes
+    /// prefilter inert.
+    fn new(max: usize) -> Option<RareByteOffset> {
+        if max > u8::MAX as usize {
+            None
         } else {
-            RareByteOffset { max: max as u8 }
+            Some(RareByteOffset { max: max as u8 })
         }
-    }
-
-    /// Returns true if and only if this offset is active. If it's inactive,
-    /// then it should not be used.
-    fn is_active(&self) -> bool {
-        self.max < u8::MAX
     }
 }
 
@@ -483,6 +503,7 @@ impl RareBytesBuilder {
     fn new() -> RareBytesBuilder {
         RareBytesBuilder {
             ascii_case_insensitive: false,
+            rare_set: ByteSet::empty(),
             byte_offsets: RareByteOffsets::empty(),
             available: true,
             count: 0,
@@ -507,8 +528,8 @@ impl RareBytesBuilder {
             return None;
         }
         let (mut bytes, mut len) = ([0; 3], 0);
-        for b in 0..256 {
-            if self.byte_offsets.set[b].is_active() {
+        for b in 0..=255 {
+            if self.rare_set.contains(b) {
                 bytes[len] = b as u8;
                 len += 1;
             }
@@ -539,15 +560,25 @@ impl RareBytesBuilder {
     /// All patterns added to an Aho-Corasick automaton should be added to this
     /// builder before attempting to construct the prefilter.
     fn add(&mut self, bytes: &[u8]) {
+        // If we've already given up, then do nothing.
+        if !self.available {
+            return;
+        }
         // If we've already blown our budget, then don't waste time looking
         // for more rare bytes.
         if self.count > 3 {
             self.available = false;
             return;
         }
+        // If the pattern is too long, then our offset table is bunk, so
+        // give up.
+        if bytes.len() >= 256 {
+            self.available = false;
+            return;
+        }
         let mut rarest = match bytes.get(0) {
             None => return,
-            Some(&b) => (b, 0, freq_rank(b)),
+            Some(&b) => (b, freq_rank(b)),
         };
         // The idea here is to look for the rarest byte in each pattern, and
         // add that to our set. As a special exception, if we see a byte that
@@ -558,33 +589,35 @@ impl RareBytesBuilder {
         // were searching for `Sherlock` and `lockjaw`, then this would pick
         // `k` for both patterns, resulting in the use of `memchr` instead of
         // `memchr2` for `k` and `j`.
+        let mut found = false;
         for (pos, &b) in bytes.iter().enumerate() {
-            if self.byte_offsets.set[b as usize].is_active() {
-                self.add_rare_byte(b, pos);
-                return;
+            self.byte_offsets.set(b, RareByteOffset::new(pos).unwrap());
+            if found {
+                continue;
+            }
+            if self.rare_set.contains(b) {
+                found = true;
+                continue;
             }
             let rank = freq_rank(b);
-            if rank < rarest.2 {
-                rarest = (b, pos, rank);
+            if rank < rarest.1 {
+                rarest = (b, rank);
             }
         }
-        self.add_rare_byte(rarest.0, rarest.1);
+        if !found {
+            self.add_rare_byte(rarest.0);
+        }
     }
 
-    fn add_rare_byte(&mut self, byte: u8, pos: usize) {
-        self.add_one_byte(byte, pos);
+    fn add_rare_byte(&mut self, byte: u8) {
+        self.add_one_rare_byte(byte);
         if self.ascii_case_insensitive {
-            self.add_one_byte(opposite_ascii_case(byte), pos);
+            self.add_one_rare_byte(opposite_ascii_case(byte));
         }
     }
 
-    fn add_one_byte(&mut self, byte: u8, pos: usize) {
-        let off = RareByteOffset::new(pos);
-        if !off.is_active() {
-            self.available = false;
-            return;
-        }
-        if self.byte_offsets.apply(byte, off) {
+    fn add_one_rare_byte(&mut self, byte: u8) {
+        if self.rare_set.insert(byte) {
             self.count += 1;
             self.rank_sum += freq_rank(byte) as u16;
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1087,6 +1087,19 @@ fn regression_ascii_case_insensitive_no_exponential() {
     assert!(ac.find("").is_none());
 }
 
+// See: https://github.com/BurntSushi/aho-corasick/issues/53
+//
+// This test ensures that the rare byte prefilter works in a particular corner
+// case. In particular, the shift offset detected for '/' in the patterns below
+// was incorrect, leading to a false negative.
+#[test]
+fn regression_rare_byte_prefilter() {
+    use AhoCorasick;
+
+    let ac = AhoCorasick::new_auto_configured(&["ab/j/", "x/"]);
+    assert!(ac.is_match("ab/j/"));
+}
+
 fn run_search_tests<F: FnMut(&SearchTest) -> Vec<Match>>(
     which: TestCollection,
     mut f: F,


### PR DESCRIPTION
This fixes a rather nasty bug that occurred when the rare byte prefilter
computed its shift offset incorrectly. In particular, when a rare byte
is found using a prefilter, we shift backwards in the haystack by the
maximum amount possible before confirming whether a match exists or not.
If this shift is not actually the maximum amount possible, then it's
quite possible that we will miss a match. (N.B. The prefilter
infrastructure takes care to avoid accidentally quadratic behavior.)

The specific regression in this case was caused by searching for these
two patterns:

    ab/j/
    x/

which would erroneously fail to match this haystack

    ab/j/

When prefilters are enabled (the default), this particular search would
use the "rare two byte" prefilter. Specifically, it would detect '/' and
'j' as rare bytes, with '1' as the max offset for '/' and '3' as the max
offset for 'j'. The former is clearly incorrect, since '/' occurs at
offset 4 in the first pattern. This was being incorrectly computed
because we weren't actually looking at all possible bytes in all
patterns and recording their offsets. Once we found a rare byte, we
stopped trying to find more occurrences of it.

We fix this byte now recording the maximum offsets of _all_ bytes for
_all_ patterns given. That way, we're guaranteed to have the correct
maximal shift amount for any rare byte found.

Fixes #53
