### PR TITLE
prefilter: fix another case insensitive prefilter bug

### DIFF
--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -637,8 +637,8 @@ impl Builder {
             heap_bytes: 0,
             prefilter: nfa.prefilter_obj().map(|p| p.clone()),
             byte_classes: byte_classes.clone(),
-            trans: trans,
-            matches: matches,
+            trans,
+            matches,
         };
         for id in (0..nfa.state_len()).map(S::from_usize) {
             repr.matches[id.to_usize()].extend_from_slice(nfa.matches(id));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,6 @@ impl Match {
 
     #[inline]
     fn from_span(id: usize, start: usize, end: usize) -> Match {
-        Match { pattern: id, len: end - start, end: end }
+        Match { pattern: id, len: end - start, end }
     }
 }

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -194,7 +194,7 @@ impl<S: StateID> NFA<S> {
             trans,
             // Anchored automatons do not have any failure transitions.
             fail: if self.anchored { dead_id() } else { self.start_id },
-            depth: depth,
+            depth,
             matches: vec![],
         });
         Ok(id)
@@ -207,7 +207,7 @@ impl<S: StateID> NFA<S> {
             trans,
             // Anchored automatons do not have any failure transitions.
             fail: if self.anchored { dead_id() } else { self.start_id },
-            depth: depth,
+            depth,
             matches: vec![],
         });
         Ok(id)
@@ -619,7 +619,7 @@ struct Compiler<'a, S: StateID> {
 impl<'a, S: StateID> Compiler<'a, S> {
     fn new(builder: &'a Builder) -> Result<Compiler<'a, S>> {
         Ok(Compiler {
-            builder: builder,
+            builder,
             prefilter: prefilter::Builder::new(builder.match_kind)
                 .ascii_case_insensitive(builder.ascii_case_insensitive),
             nfa: NFA {
@@ -1263,6 +1263,7 @@ impl<S: StateID> fmt::Debug for NFA<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "NFA(")?;
         writeln!(f, "match_kind: {:?}", self.match_kind)?;
+        writeln!(f, "prefilter: {:?}", self.prefilter)?;
         writeln!(f, "{}", "-".repeat(79))?;
         for (id, s) in self.states.iter().enumerate() {
             let mut trans = vec![];

--- a/src/packed/api.rs
+++ b/src/packed/api.rs
@@ -269,8 +269,8 @@ impl Builder {
         };
         Some(Searcher {
             config: self.config.clone(),
-            patterns: patterns,
-            rabinkarp: rabinkarp,
+            patterns,
+            rabinkarp,
             search_kind,
             minimum_len,
         })

--- a/src/packed/teddy/compile.rs
+++ b/src/packed/teddy/compile.rs
@@ -119,7 +119,7 @@ impl Builder {
         // safe to call functions marked with the `avx2` target feature.
         match (masks.len(), avx, fat) {
             (1, false, _) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddySlim1Mask128(
                     runtime::TeddySlim1Mask128 {
@@ -128,7 +128,7 @@ impl Builder {
                 ),
             }),
             (1, true, false) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddySlim1Mask256(
                     runtime::TeddySlim1Mask256 {
@@ -137,7 +137,7 @@ impl Builder {
                 ),
             }),
             (1, true, true) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddyFat1Mask256(
                     runtime::TeddyFat1Mask256 {
@@ -146,7 +146,7 @@ impl Builder {
                 ),
             }),
             (2, false, _) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddySlim2Mask128(
                     runtime::TeddySlim2Mask128 {
@@ -156,7 +156,7 @@ impl Builder {
                 ),
             }),
             (2, true, false) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddySlim2Mask256(
                     runtime::TeddySlim2Mask256 {
@@ -166,7 +166,7 @@ impl Builder {
                 ),
             }),
             (2, true, true) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddyFat2Mask256(
                     runtime::TeddyFat2Mask256 {
@@ -176,7 +176,7 @@ impl Builder {
                 ),
             }),
             (3, false, _) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddySlim3Mask128(
                     runtime::TeddySlim3Mask128 {
@@ -187,7 +187,7 @@ impl Builder {
                 ),
             }),
             (3, true, false) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddySlim3Mask256(
                     runtime::TeddySlim3Mask256 {
@@ -198,7 +198,7 @@ impl Builder {
                 ),
             }),
             (3, true, true) => Some(Teddy {
-                buckets: buckets,
+                buckets,
                 max_pattern_id: patterns.max_pattern_id(),
                 exec: runtime::Exec::TeddyFat3Mask256(
                     runtime::TeddyFat3Mask256 {

--- a/src/prefilter.rs
+++ b/src/prefilter.rs
@@ -591,7 +591,7 @@ impl RareBytesBuilder {
         // `memchr2` for `k` and `j`.
         let mut found = false;
         for (pos, &b) in bytes.iter().enumerate() {
-            self.byte_offsets.set(b, RareByteOffset::new(pos).unwrap());
+            self.set_offset(pos, b);
             if found {
                 continue;
             }
@@ -606,6 +606,15 @@ impl RareBytesBuilder {
         }
         if !found {
             self.add_rare_byte(rarest.0);
+        }
+    }
+
+    fn set_offset(&mut self, pos: usize, byte: u8) {
+        // This unwrap is OK because pos is never bigger than our max.
+        let offset = RareByteOffset::new(pos).unwrap();
+        self.byte_offsets.set(byte, offset);
+        if self.ascii_case_insensitive {
+            self.byte_offsets.set(opposite_ascii_case(byte), offset);
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1100,6 +1100,32 @@ fn regression_rare_byte_prefilter() {
     assert!(ac.is_match("ab/j/"));
 }
 
+#[test]
+fn regression_case_insensitive_prefilter() {
+    use AhoCorasickBuilder;
+
+    for c in b'a'..b'z' {
+        for c2 in b'a'..b'z' {
+            let c = c as char;
+            let c2 = c2 as char;
+            let needle = format!("{}{}", c, c2).to_lowercase();
+            let haystack = needle.to_uppercase();
+            let ac = AhoCorasickBuilder::new()
+                .ascii_case_insensitive(true)
+                .prefilter(true)
+                .build(&[&needle]);
+            assert_eq!(
+                1,
+                ac.find_iter(&haystack).count(),
+                "failed to find {:?} in {:?}\n\nautomaton:\n{:?}",
+                needle,
+                haystack,
+                ac,
+            );
+        }
+    }
+}
+
 fn run_search_tests<F: FnMut(&SearchTest) -> Vec<Match>>(
     which: TestCollection,
     mut f: F,


### PR DESCRIPTION
This fixes another bug in the handling of case insensitivity inside
the rare byte prefilter. In particular, we were not correctly populating
the byte offset table when ASCII case insensitivity was enabled. Instead
of just setting the offsets for bytes we've seen, we also need to set
offsets for the ASCII case insensitive version of each byte we see. We
add that in this commit along with a regression test.

Fixes #55