### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ let rdr = "The quick brown fox.";
 let mut wtr = vec![];
 
 let ac = AhoCorasick::new(patterns);
-ac.stream_replace_all(rdr.as_bytes(), &mut wtr, replace_with)?;
+ac.stream_replace_all(rdr.as_bytes(), &mut wtr, replace_with)
+    .expect("stream_replace_all failed");
 assert_eq!(b"The slow grey sloth.".to_vec(), wtr);
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,11 +186,11 @@ performance in some cases. For that reason, prefilters can be disabled via
 compile_error!("`std` feature is currently required to build this crate");
 
 extern crate memchr;
-#[cfg(test)]
+#[cfg(doctest)]
 #[macro_use]
 extern crate doc_comment;
 
-#[cfg(test)]
+#[cfg(doctest)]
 doctest!("../README.md");
 
 pub use ahocorasick::{


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.