### PR TITLE
prefilter: fix bug when doing a stream search

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -50,7 +50,9 @@ impl Buffer {
         // reasons, so we set a lower bound of `8 * min`.
         //
         // TODO: It would be good to find a way to test the streaming
-        // implementation with the minimal buffer size.
+        // implementation with the minimal buffer size. For now, we just
+        // uncomment out the next line and comment out the subsequent line.
+        // let capacity = 1 + min;
         let capacity = cmp::max(min * 8, DEFAULT_BUFFER_CAPACITY);
         Buffer { buf: vec![0; capacity], min, end: 0 }
     }

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -43,6 +43,10 @@ impl<S: StateID> DFA<S> {
         self.repr().pattern_count
     }
 
+    pub fn prefilter(&self) -> Option<&dyn Prefilter> {
+        self.repr().prefilter.as_ref().map(|p| p.as_ref())
+    }
+
     pub fn start_state(&self) -> S {
         self.repr().start_id
     }


### PR DESCRIPTION
This fixes yet another bug in the prefilter. Sigh. This only occurs when
doing a stream search. The problem is that the stream handling code
assumes that if no match is found at the end of the buffer, then the
current state of the automaton is correctly updated and the buffer can
be rolled.

With most prefilters that look for a candidate *start* of a match, this
is okay. If a prefilter can't find anything, then there's nothing to
start and the current state remains in the starting state.

But if the prefilter looks for a byte that may not be at the start of
the match---like the rare byte prefilter---then we cannot assume that a
match doesn't begin near the end of the buffer searched. And in this
case, the internal implementation of search doesn't correctly hold up
it's contract because the current state won't be updated. That is, there
is an embedded assumption that if a prefilter fails then there is no
match and thus there is no need to update the current state ID. But of
course, this is just not true in a streaming context.

The right way to fix this is unfortunately to rethink how we've
implemented stream searching and make it aware of these kinds of
prefilters. I think, anyway. The other option would be to fix the lower
level search APIs to always make sure the current state ID is correct.
That would fix everything, but that seems tricky and probably requires
some delicate handling.

So for now, we just disable a prefilter entirely if it's a rare byte
prefilter and we're doing a stream search. We could build a backup
prefilter and still use that, but it feels like a gross hack. At least
now, we preserve correctness.

Kudos to @ogoffart who did the initial investigation here and came up
with a regression test, which is included in this commit. Note though,
that some tests did fail (now fixed) when the buffer's size is set to its minimum. So
there was a regression at some point because we aren't getting the best
test coverage. We should just bite the bullet and make the buffer size
configurable as an internal API so that tests can tweak it and provoke
more edge cases.

Fixes #64