### PR TITLE
some simplifications before the 1.0 release

### DIFF
--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -2574,8 +2574,8 @@ impl<A> AcAutomaton for A where
 #[doc(hidden)]
 unsafe impl Automaton for Arc<dyn AcAutomaton> {
     #[inline(always)]
-    fn start_state(&self, input: &Input<'_>) -> Result<StateID, MatchError> {
-        (**self).start_state(input)
+    fn start_state(&self, anchored: Anchored) -> Result<StateID, MatchError> {
+        (**self).start_state(anchored)
     }
 
     #[inline(always)]

--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -1847,6 +1847,32 @@ impl AhoCorasick {
         self.aut.match_kind()
     }
 
+    /// Returns the length of the shortest pattern matched by this automaton.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use aho_corasick::AhoCorasick;
+    ///
+    /// let ac = AhoCorasick::new(&["foo", "bar", "quux", "baz"]).unwrap();
+    /// assert_eq!(3, ac.min_pattern_len());
+    /// ```
+    ///
+    /// Note that an `AhoCorasick` automaton has a minimum length of `0` if
+    /// and only if it can match the empty string:
+    ///
+    /// ```
+    /// use aho_corasick::AhoCorasick;
+    ///
+    /// let ac = AhoCorasick::new(&["foo", "", "quux", "baz"]).unwrap();
+    /// assert_eq!(0, ac.min_pattern_len());
+    /// ```
+    pub fn min_pattern_len(&self) -> usize {
+        self.aut.min_pattern_len()
+    }
+
     /// Returns the length of the longest pattern matched by this automaton.
     ///
     /// # Examples
@@ -2631,6 +2657,11 @@ unsafe impl Automaton for Arc<dyn AcAutomaton> {
     #[inline(always)]
     fn pattern_len(&self, pid: PatternID) -> usize {
         (**self).pattern_len(pid)
+    }
+
+    #[inline(always)]
+    fn min_pattern_len(&self) -> usize {
+        (**self).min_pattern_len()
     }
 
     #[inline(always)]

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -18,7 +18,7 @@ use crate::{
         int::{Usize, U32},
         prefilter::Prefilter,
         primitives::{IteratorIndexExt, PatternID, SmallIndex, StateID},
-        search::{Anchored, Input, MatchKind, StartKind},
+        search::{Anchored, MatchKind, StartKind},
         special::Special,
     },
 };
@@ -187,12 +187,12 @@ impl DFA {
 // all other methods are correct as well.
 unsafe impl Automaton for DFA {
     #[inline(always)]
-    fn start_state(&self, input: &Input<'_>) -> Result<StateID, MatchError> {
+    fn start_state(&self, anchored: Anchored) -> Result<StateID, MatchError> {
         // Either of the start state IDs can be DEAD, in which case, support
         // for that type of search is not provided by this DFA. Which start
         // state IDs are inactive depends on the 'StartKind' configuration at
         // DFA construction time.
-        match input.get_anchored() {
+        match anchored {
             Anchored::No => {
                 let start = self.special.start_unanchored_id;
                 if start == DFA::DEAD {

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -128,6 +128,8 @@ pub struct DFA {
     /// The equivalence classes for this DFA. All transitions are defined on
     /// equivalence classes and not on the 256 distinct byte values.
     byte_classes: ByteClasses,
+    /// The length of the shortest pattern in this automaton.
+    min_pattern_len: usize,
     /// The length of the longest pattern in this automaton.
     max_pattern_len: usize,
     /// The information required to deduce which states are "special" in this
@@ -260,18 +262,25 @@ unsafe impl Automaton for DFA {
     }
 
     #[inline(always)]
+    fn min_pattern_len(&self) -> usize {
+        self.min_pattern_len
+    }
+
+    #[inline(always)]
     fn max_pattern_len(&self) -> usize {
         self.max_pattern_len
     }
 
     #[inline(always)]
     fn match_len(&self, sid: StateID) -> usize {
+        debug_assert!(self.is_match(sid));
         let offset = (sid.as_usize() >> self.stride2) - 2;
         self.matches[offset].len()
     }
 
     #[inline(always)]
     fn match_pattern(&self, sid: StateID, index: usize) -> PatternID {
+        debug_assert!(self.is_match(sid));
         let offset = (sid.as_usize() >> self.stride2) - 2;
         self.matches[offset][index]
     }
@@ -360,6 +369,7 @@ impl core::fmt::Debug for DFA {
         writeln!(f, "prefilter: {:?}", self.prefilter.is_some())?;
         writeln!(f, "state length: {:?}", self.state_len)?;
         writeln!(f, "pattern length: {:?}", self.patterns_len())?;
+        writeln!(f, "shortest pattern length: {:?}", self.min_pattern_len)?;
         writeln!(f, "longest pattern length: {:?}", self.max_pattern_len)?;
         writeln!(f, "alphabet length: {:?}", self.alphabet_len)?;
         writeln!(f, "stride: {:?}", 1 << self.stride2)?;
@@ -490,6 +500,7 @@ impl Builder {
             alphabet_len: byte_classes.alphabet_len(),
             stride2: byte_classes.stride2(),
             byte_classes,
+            min_pattern_len: nnfa.min_pattern_len(),
             max_pattern_len: nnfa.max_pattern_len(),
             // The special state IDs are set later.
             special: Special::zero(),

--- a/src/nfa/contiguous.rs
+++ b/src/nfa/contiguous.rs
@@ -18,7 +18,7 @@ use crate::{
         int::{Usize, U32},
         prefilter::Prefilter,
         primitives::{IteratorIndexExt, PatternID, SmallIndex, StateID},
-        search::{Anchored, Input, MatchKind},
+        search::{Anchored, MatchKind},
         special::Special,
     },
 };
@@ -173,8 +173,8 @@ impl NFA {
 // all other methods are correct as well.
 unsafe impl Automaton for NFA {
     #[inline(always)]
-    fn start_state(&self, input: &Input<'_>) -> Result<StateID, MatchError> {
-        match input.get_anchored() {
+    fn start_state(&self, anchored: Anchored) -> Result<StateID, MatchError> {
+        match anchored {
             Anchored::No => Ok(self.special.start_unanchored_id),
             Anchored::Yes => Ok(self.special.start_anchored_id),
         }

--- a/src/nfa/contiguous.rs
+++ b/src/nfa/contiguous.rs
@@ -110,6 +110,8 @@ pub struct NFA {
     /// sparse, are defined on equivalence classes and not on the 256 distinct
     /// byte values.
     byte_classes: ByteClasses,
+    /// The length of the shortest pattern in this automaton.
+    min_pattern_len: usize,
     /// The length of the longest pattern in this automaton.
     max_pattern_len: usize,
     /// The information required to deduce which states are "special" in this
@@ -261,6 +263,11 @@ unsafe impl Automaton for NFA {
     }
 
     #[inline(always)]
+    fn min_pattern_len(&self) -> usize {
+        self.min_pattern_len
+    }
+
+    #[inline(always)]
     fn max_pattern_len(&self) -> usize {
         self.max_pattern_len
     }
@@ -341,6 +348,7 @@ impl core::fmt::Debug for NFA {
         writeln!(f, "prefilter: {:?}", self.prefilter.is_some())?;
         writeln!(f, "state length: {:?}", self.state_len)?;
         writeln!(f, "pattern length: {:?}", self.patterns_len())?;
+        writeln!(f, "shortest pattern length: {:?}", self.min_pattern_len)?;
         writeln!(f, "longest pattern length: {:?}", self.max_pattern_len)?;
         writeln!(f, "alphabet length: {:?}", self.alphabet_len)?;
         writeln!(f, "byte classes: {:?}", self.byte_classes)?;
@@ -866,6 +874,7 @@ impl Builder {
             match_kind: nnfa.match_kind(),
             alphabet_len: byte_classes.alphabet_len(),
             byte_classes,
+            min_pattern_len: nnfa.min_pattern_len(),
             max_pattern_len: nnfa.max_pattern_len(),
             // The special state IDs are set later.
             special: Special::zero(),

--- a/src/nfa/noncontiguous.rs
+++ b/src/nfa/noncontiguous.rs
@@ -21,7 +21,7 @@ use crate::{
         prefilter::{self, opposite_ascii_case, Prefilter},
         primitives::{IteratorIndexExt, PatternID, SmallIndex, StateID},
         remapper::Remapper,
-        search::{Anchored, Input, MatchKind},
+        search::{Anchored, MatchKind},
         special::Special,
     },
 };
@@ -239,8 +239,8 @@ impl NFA {
 // all other methods are correct as well.
 unsafe impl Automaton for NFA {
     #[inline(always)]
-    fn start_state(&self, input: &Input<'_>) -> Result<StateID, MatchError> {
-        match input.get_anchored() {
+    fn start_state(&self, anchored: Anchored) -> Result<StateID, MatchError> {
+        match anchored {
             Anchored::No => Ok(self.special.start_unanchored_id),
             Anchored::Yes => Ok(self.special.start_anchored_id),
         }

--- a/src/transducer.rs
+++ b/src/transducer.rs
@@ -92,7 +92,7 @@ impl<A: Automaton> fst::Automaton for Unanchored<A> {
     }
 }
 
-/// Represents an unanchored Aho-Corasick search of a finite state transducer.
+/// Represents an anchored Aho-Corasick search of a finite state transducer.
 ///
 /// Wrapping an Aho-Corasick automaton in `Unanchored` will fail if the
 /// underlying automaton does not support unanchored searches.

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -182,6 +182,13 @@ impl MatchError {
     pub fn unsupported_overlapping(got: MatchKind) -> MatchError {
         MatchError::new(MatchErrorKind::UnsupportedOverlapping { got })
     }
+
+    /// Create a new "unsupported empty pattern" error. This occurs when the
+    /// caller requests a search for which matching an automaton that contains
+    /// an empty pattern string is not supported.
+    pub fn unsupported_empty() -> MatchError {
+        MatchError::new(MatchErrorKind::UnsupportedEmpty)
+    }
 }
 
 /// The underlying kind of a [`MatchError`].
@@ -209,6 +216,9 @@ pub enum MatchErrorKind {
         /// The match semantics for the automaton that was used.
         got: MatchKind,
     },
+    /// An error indicating that the operation requested doesn't support
+    /// automatons that contain an empty pattern string.
+    UnsupportedEmpty,
 }
 
 #[cfg(feature = "std")]
@@ -235,6 +245,13 @@ impl core::fmt::Display for MatchError {
                     f,
                     "match kind {:?} does not support overlapping searches",
                     got,
+                )
+            }
+            MatchErrorKind::UnsupportedEmpty => {
+                write!(
+                    f,
+                    "matching with an empty pattern string is not \
+                     supported for this operation",
                 )
             }
         }

--- a/src/util/search.rs
+++ b/src/util/search.rs
@@ -930,6 +930,14 @@ impl Match {
         self.span().is_empty()
     }
 
+    /// Returns the length of this match.
+    ///
+    /// This returns `0` in precisely the cases that `is_empty` returns `true`.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.span().len()
+    }
+
     /// Returns a new match with `offset` added to its span's `start` and `end`
     /// values.
     #[inline]


### PR DESCRIPTION
This makes a few implementation simplifications and also does some small API tweaks:

* `Automaton::start_state` now just accepts `Anchored` instead of a full `Input`. All implementations only actually determined the start state from the anchored mode, so there's no real need to pass in the full `Input` configuration. Indeed, there were a few cases where dummy `Input` values were being constructed just to pass in the `Anchored` mode.
* Re-implement stream searching. I did this to try and re-contextualize how it works. Overall, I didn't make a lot of great progress. Things like leftmost-first searching still seem difficult. I did manage to write a much simpler stream search iterator without using a roll buffer, but it turns out that I couldn't make that work for the stream replacement APIs. The replacement APIs really need the full chunks of bytes, and in particular matches, to be contiguous in memory.