### PR TITLE
nfa/contiguous: expand utility of contiguous NFA at cost of memory

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,6 @@
+{
+  "rust-analyzer.linkedProjects": [
+    "aho-corasick-debug/Cargo.toml",
+    "Cargo.toml"
+  ]
+}

--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -1947,7 +1947,7 @@ impl AhoCorasick {
     ///     .ascii_case_insensitive(true)
     ///     .build(&["foobar", "bruce", "triskaidekaphobia", "springsteen"])
     ///     .unwrap();
-    /// assert_eq!(2_308, ac.memory_usage());
+    /// assert_eq!(2_584, ac.memory_usage());
     ///
     /// let ac = AhoCorasick::builder()
     ///     .kind(AhoCorasickKind::DFA)

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -1245,7 +1245,7 @@ impl<'r> StreamChunk<'r> {
     }
 }
 
-#[inline(always)]
+#[inline(never)]
 pub(crate) fn try_find_fwd<A: Automaton + ?Sized>(
     aut: &A,
     input: &Input<'_>,
@@ -1410,7 +1410,7 @@ fn try_find_fwd_imp<A: Automaton + ?Sized>(
 }
 
 #[inline(never)]
-pub(crate) fn try_find_overlapping_fwd<A: Automaton + ?Sized>(
+fn try_find_overlapping_fwd<A: Automaton + ?Sized>(
     aut: &A,
     input: &Input<'_>,
     state: &mut OverlappingState,


### PR DESCRIPTION
This commit does some surgery on the in memory representation of
the contiguous NFA. Previously, we had been packing both the next
transition ID and the byte corresponding to that transition into a
single u32. In order to achieve that, we placed a restriction on the
allowable state IDs: they must be representable using 24 bits.

While an automaton with 2^24 states is quite large, it's actually
worse than that. Since a contiguous NFA uses a predominantly sparse
representation, state IDs are not consecutive integers, but rather,
offsets into a `Vec<u32>`. Since a state ID has to be offset and state
IDs are limited to 2^24 bits, this implies that the overall `Vec<u32>`
is itself limited to a length of 2^24. Which is... not _that_ big. It's
easy to blow that limit with 1,000,000 randomly selected Wikipedia
titles, for example.

While such a limit might be justifiable if producing such automatons
would otherwise be impractical, that is not the case. It only takes a
few seconds to do it on my machine, and the total automaton size uses
around 168MB of heap. Pretty large, but not impractically so.

I therefore concluded that this limitation was bogus. In particular,
if you can't build a contiguous NFA, your options are quite limited.
A DFA will take forever to build *and* will be much much larger. A
noncontiguous NFA will work, but it will also be larger and usually
slower.

... so I changed the contiguous NFA implementation to remove this
restriction. Of course, this also means we can longer pack both the
transition alphabet element and the state ID into a single u32. This
also prevents us from packing the failure transition ID with the "kind"
of the state.

This results in a contiguous NFA that is almost twice as big on a
random sample of 100,000 Wikipedia titles (with leftmost-longest match
semantics). I was able to reclaim some of this by introducing a new kind
of state that is specifically used for states with a single transition.
Since they are overwhelmingly the most common type of state, it makes
sense to focus our efforts on it.

Overall, the contiguous NFA is now a little bigger than it was, but
still *a lot* smaller than both the noncontiguous NFA and of course the
DFA. Search speed appears to remain the same. But it can now support
many more patterns. I'm able to build an automaton with ~15,700,000
Wikipedia titles in about 20 seconds. It does use 2GB of memory, but it
can now actually be done. (The non-contiguous NFA is about 10GB of
memory, which does still need to be built first, but then it can be
discarded once the contiguous NFA is built.)
