### PR TITLE
Add interleaved NFA implementation

### DIFF
--- a/aho-corasick-debug/main.rs
+++ b/aho-corasick-debug/main.rs
@@ -59,6 +59,7 @@ impl Args {
                         "auto",
                         "noncontiguous",
                         "contiguous",
+                        "interleaved",
                         "dfa",
                     ])
                     .default_value("auto"),
@@ -116,6 +117,7 @@ impl Args {
             "auto" => None,
             "noncontiguous" => Some(AhoCorasickKind::NoncontiguousNFA),
             "contiguous" => Some(AhoCorasickKind::ContiguousNFA),
+            "interleaved" => Some(AhoCorasickKind::InterleavedNFA),
             "dfa" => Some(AhoCorasickKind::DFA),
             _ => unreachable!(),
         };

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -54,6 +54,17 @@ fn define_aho_corasick<B: AsRef<[u8]>>(
     });
 
     let haystack = corpus.to_vec();
+    let name = format!("nfa/interleaved/{}", bench_name);
+    let aut = AhoCorasick::builder()
+        .match_kind(MatchKind::LeftmostFirst)
+        .kind(Some(AhoCorasickKind::InterleavedNFA))
+        .build(patterns.clone())
+        .unwrap();
+    define(c, group_name, &name, corpus, move |b| {
+        b.iter(|| assert_eq!(count, aut.find_iter(&haystack).count()));
+    });
+
+    let haystack = corpus.to_vec();
     let name = format!("dfa/{}", bench_name);
     let aut = AhoCorasick::builder()
         .match_kind(MatchKind::LeftmostFirst)

--- a/bench/src/build.rs
+++ b/bench/src/build.rs
@@ -91,6 +91,32 @@ fn define_build<B: AsRef<[u8]>>(
     }
 
     let pats = patterns.clone();
+    let name = format!("nfa/interleaved/{}", bench_name);
+    if long {
+        define_long(c, "build", &name, &[], move |b| {
+            b.iter(|| {
+                black_box(
+                    AhoCorasick::builder()
+                        .kind(Some(AhoCorasickKind::InterleavedNFA))
+                        .build(&pats)
+                        .unwrap(),
+                )
+            })
+        });
+    } else {
+        define(c, "build", &name, &[], move |b| {
+            b.iter(|| {
+                black_box(
+                    AhoCorasick::builder()
+                        .kind(Some(AhoCorasickKind::InterleavedNFA))
+                        .build(&pats)
+                        .unwrap(),
+                )
+            })
+        });
+    }
+
+    let pats = patterns.clone();
     let name = format!("dfa/{}", bench_name);
     if long {
         define_long(c, "build", &name, &[], move |b| {

--- a/bench/src/random.rs
+++ b/bench/src/random.rs
@@ -72,6 +72,28 @@ fn misc(c: &mut Criterion) {
             "ghijkl", "hijklm", "ijklmn", "jklmno",
         ],
     );
+
+    // Test on patterns that fills up the alphabet.
+    // - The root state is dense
+    // - The children of the root states are dense
+    // - The grandchildren all have only one valid transition.
+
+    // Build [
+    //      "\x00\x00\x00\x00", "\x00\x01\x01\x01", ..., "\x00\xFF\xFF\xFF",
+    //      "\x01\x00\x00\x00", "\x01\x01\x01\x01", ..., "\x01\xFF\xFF\xFF",
+    //      ..,
+    //      "\xFF\x00\x00\x00", "\xFF\x01\x01\x01", ..., "\xFF\xFF\xFF\xFF",
+    // ]
+    let pats: Vec<Vec<u8>> = (0_u8..255)
+        .flat_map(|b| {
+            (0_u8..255).map(move |c| {
+                std::iter::once(c)
+                    .chain(std::iter::repeat(b).take(3))
+                    .collect::<Vec<_>>()
+            })
+        })
+        .collect();
+    define_random(c, "dense-root", 16, pats);
 }
 
 /// Various benchmarks using a large pattern set.

--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -8,7 +8,7 @@ use alloc::{string::String, sync::Arc, vec::Vec};
 use crate::{
     automaton::{self, Automaton, OverlappingState},
     dfa,
-    nfa::{contiguous, noncontiguous},
+    nfa::{contiguous, interleaved, noncontiguous},
     util::{
         error::{BuildError, MatchError},
         prefilter::Prefilter,
@@ -2134,6 +2134,7 @@ impl<'a, R: std::io::Read> Iterator for StreamFindIter<'a, R> {
 pub struct AhoCorasickBuilder {
     nfa_noncontiguous: noncontiguous::Builder,
     nfa_contiguous: contiguous::Builder,
+    nfa_interleaved: interleaved::Builder,
     dfa: dfa::Builder,
     kind: Option<AhoCorasickKind>,
     start_kind: StartKind,
@@ -2195,6 +2196,12 @@ impl AhoCorasickBuilder {
                     let cnfa =
                         self.nfa_contiguous.build_from_noncontiguous(&nfa)?;
                     (Arc::new(cnfa), AhoCorasickKind::ContiguousNFA)
+                }
+                Some(AhoCorasickKind::InterleavedNFA) => {
+                    debug!("forcefully chose interleaved NFA");
+                    let cnfa =
+                        self.nfa_interleaved.build_from_noncontiguous(&nfa)?;
+                    (Arc::new(cnfa), AhoCorasickKind::InterleavedNFA)
                 }
                 Some(AhoCorasickKind::DFA) => {
                     debug!("forcefully chose DFA");
@@ -2341,6 +2348,7 @@ impl AhoCorasickBuilder {
     pub fn match_kind(&mut self, kind: MatchKind) -> &mut AhoCorasickBuilder {
         self.nfa_noncontiguous.match_kind(kind);
         self.nfa_contiguous.match_kind(kind);
+        self.nfa_interleaved.match_kind(kind);
         self.dfa.match_kind(kind);
         self
     }
@@ -2476,6 +2484,7 @@ impl AhoCorasickBuilder {
     ) -> &mut AhoCorasickBuilder {
         self.nfa_noncontiguous.ascii_case_insensitive(yes);
         self.nfa_contiguous.ascii_case_insensitive(yes);
+        self.nfa_interleaved.ascii_case_insensitive(yes);
         self.dfa.ascii_case_insensitive(yes);
         self
     }
@@ -2546,6 +2555,7 @@ impl AhoCorasickBuilder {
     pub fn prefilter(&mut self, yes: bool) -> &mut AhoCorasickBuilder {
         self.nfa_noncontiguous.prefilter(yes);
         self.nfa_contiguous.prefilter(yes);
+        self.nfa_interleaved.prefilter(yes);
         self.dfa.prefilter(yes);
         self
     }
@@ -2609,6 +2619,7 @@ impl AhoCorasickBuilder {
     /// bytes instead of the equivalence classes.
     pub fn byte_classes(&mut self, yes: bool) -> &mut AhoCorasickBuilder {
         self.nfa_contiguous.byte_classes(yes);
+        self.nfa_interleaved.byte_classes(yes);
         self.dfa.byte_classes(yes);
         self
     }
@@ -2627,6 +2638,8 @@ pub enum AhoCorasickKind {
     NoncontiguousNFA,
     /// Use a contiguous NFA.
     ContiguousNFA,
+    /// Use an interleaved NFA,
+    InterleavedNFA,
     /// Use a DFA. Warning: DFAs typically use a large amount of memory.
     DFA,
 }

--- a/src/nfa/interleaved.rs
+++ b/src/nfa/interleaved.rs
@@ -1,0 +1,731 @@
+/*!
+Provides an interleaved NFA implementation of Aho-Corasick.
+
+This is a low-level API that generally only needs to be used in niche
+circumstances. When possible, prefer using [`AhoCorasick`](crate::AhoCorasick)
+instead of an interleaved NFA directly. Using an `NFA` directly is typically
+only necessary when one needs access to the [`Automaton`] trait implementation.
+*/
+
+use std::collections::HashSet;
+
+use alloc::{collections::VecDeque, vec, vec::Vec};
+
+use crate::{
+    automaton::Automaton,
+    nfa::noncontiguous,
+    util::{
+        alphabet::ByteClasses,
+        debug::DebugByte,
+        error::{BuildError, MatchError},
+        prefilter::Prefilter,
+        primitives::{PatternID, SmallIndex, StateID},
+        search::{Anchored, MatchKind},
+    },
+};
+
+/// An interleaved NFA implementation of Aho-Corasick.
+///
+/// When possible, prefer using [`AhoCorasick`](crate::AhoCorasick) instead of
+/// this type directly. Using an `NFA` directly is typically only necessary
+/// when one needs access to the [`Automaton`] trait implementation.
+///
+/// This NFA can only be built by first constructing a [`noncontiguous::NFA`].
+/// Both [`NFA::new`] and [`Builder::build`] do this for you automatically,
+/// but [`Builder::build_from_noncontiguous`] permits doing it explicitly.
+///
+/// This implementation mostly comes from http://goo.gl/lE6zG, with however
+/// several adaptations to the design of this crate.
+///
+/// This NFA implementation optimizes the noncontiguous NFA with several
+/// optimizations to reduce the size of the automaton. A single allocation
+/// is used to store states and transitions, and transitions of each state
+/// can be interleaved together.
+///
+/// For example, lets say the Aho-Corasick contains those two states:
+///
+/// state A [ class 0x00 => state C, class 0x04 => state D, fail => state S ]
+/// state B [ class 0x01 => state E, class 0x02 => state F, fail => state V ]
+///
+/// And the alphabet has size 8.
+///
+/// The DFA would store those states like this:
+///
+/// ```text
+///   A                               B                               C
+/// | C | . | . | . | D | . | . | . | . | E | F | . | . | . | . | . | ..
+/// ```
+///
+/// For the interleaved NFA however, slots that correspond to failed
+/// transitions are considered empty, and transitions can be inserted if
+/// there is place for them:
+///
+/// ```text
+///   A       B               C
+/// | S | C | V | E | F | D | ..
+/// ```
+///
+/// The first slot is reserved for the fail transition, and the other ones
+/// are translated by one. There is however an issue in making sure that a
+/// transition is the right one. For example, to make sure that on state A
+/// and with class 0x03, the right transition is to S (fail state) instead
+/// of to state E (which belongs the B's transition table). This is done by
+/// storing not only the target state of the transition, but the offset to
+/// to the owner's state:
+///
+/// ```text
+///     A                  B                                 C
+/// | (S, 0) | (C, 1) | (V, 0) | (E, 1) | (F, 2) | (D, 5) | ..
+/// ```
+///
+/// This means that in each element of the array, we need to store a state
+/// id, and an offset, which can go from 0 to 256 included. This means 9 bits
+/// for the offset, leaving 23 bits for the state id.
+///
+/// This limits the number of states that can be stored in this NFA version.
+/// If there are too many states, the build of the automaton will fail.
+/// Building it is however quite cheap, so trying it before building another
+/// automaton kind can be worth it.
+///
+/// # Example
+///
+/// This example shows how to build an `NFA` directly and use it to execute
+/// [`Automaton::try_find`]:
+///
+/// ```
+/// use aho_corasick::{
+///     automaton::Automaton,
+///     nfa::interleaved::NFA,
+///     Input, Match,
+/// };
+///
+/// let patterns = &["b", "abc", "abcd"];
+/// let haystack = "abcd";
+///
+/// let nfa = NFA::new(patterns).unwrap();
+/// assert_eq!(
+///     Some(Match::must(0, 1..2)),
+///     nfa.try_find(&Input::new(haystack))?,
+/// );
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// It is also possible to implement your own version of `try_find`. See the
+/// [`Automaton`] documentation for an example.
+#[derive(Clone)]
+pub struct NFA {
+    /// The raw NFA representation. State IDs are indexes into this array,
+    /// and each elements packs a state id (the target of the transition)
+    /// and an offset to the state ID that is owning the transition.
+    repr: Vec<Element>,
+    /// Matches per states. This is needed because the state ids are no
+    /// longer ordered to easily detect match states. Non matching states
+    /// are not stored in the map.
+    matches: Vec<Vec<PatternID>>,
+    /// The amount of heap memory used, in bytes, by the inner Vecs of
+    /// 'matches'.
+    matches_memory_usage: usize,
+    /// The length of each pattern. This is used to compute the start offset
+    /// of a match.
+    pattern_lens: Vec<SmallIndex>,
+    /// The total number of states in this NFA.
+    state_len: usize,
+    /// A prefilter for accelerating searches, if one exists.
+    prefilter: Option<Prefilter>,
+    /// The match semantics built into this NFA.
+    match_kind: MatchKind,
+    /// The equivalence classes for this NFA. All transitions are defined
+    /// on equivalence classes and not on the 256 distinct byte values.
+    byte_classes: ByteClasses,
+    /// The length of the shortest pattern in this automaton.
+    min_pattern_len: usize,
+    /// The length of the longest pattern in this automaton.
+    max_pattern_len: usize,
+    /// The State ID for the start node, in the unanchored version.
+    start_unanchored_id: StateID,
+    /// The State ID for the start node, in the anchored version.
+    start_anchored_id: StateID,
+}
+
+impl NFA {
+    /// Create a new Aho-Corasick interleaved NFA using the default
+    /// configuration.
+    ///
+    /// Use a [`Builder`] if you want to change the configuration.
+    pub fn new<I, P>(patterns: I) -> Result<NFA, BuildError>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<[u8]>,
+    {
+        NFA::builder().build(patterns)
+    }
+
+    /// A convenience method for returning a new Aho-Corasick interleaved
+    /// NFA builder.
+    ///
+    /// This usually permits one to just import the `NFA` type.
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+
+    /// Build the automaton table using the interleaving details.
+    fn build_table(
+        &mut self,
+        nnfa: &noncontiguous::NFA,
+        interleave_state: &InterleaveState,
+    ) -> Result<(), BuildError> {
+        let InterleaveState { index_to_state_id, max_state_id } =
+            interleave_state;
+
+        // Grow the table to max_state_id + 1 + alphabet_len, to ensure the next_state_id
+        // implementation can always index into this array. Unfilled elements have
+        // offset == 0, which will always be invalid outside of state indexes.
+        self.repr =
+            vec![
+                Element::EMPTY;
+                max_state_id.as_usize() + 1 + self.byte_classes.alphabet_len()
+            ];
+
+        for (old_sid, state) in nnfa.states().iter().enumerate() {
+            let new_sid = index_to_state_id[old_sid];
+
+            // Add fail transition.
+            let new_fail = index_to_state_id[state.fail];
+            self.repr[new_sid] = Element::new(new_fail, 0)?;
+
+            // Add the byte transitions.
+            for (byte, old_target_sid) in &state.trans {
+                let new_target_sid = index_to_state_id[*old_target_sid];
+                let class = self.byte_classes.get(*byte) as u32;
+
+                let idx = new_sid.as_usize() + (class as usize) + 1;
+                self.repr[idx] = Element::new(new_target_sid, class + 1)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl NFA {
+    /// A sentinel state ID indicating that a search should stop once it has
+    /// entered this state. When a search stops, it returns a match if one
+    /// has been found, otherwise no match. An interleaved NFA always has an
+    /// actual dead state at this ID.
+    const DEAD: StateID = StateID::new_unchecked(0);
+}
+
+// SAFETY: 'start_state' always returns a valid state ID, 'next_state' always
+// returns a valid state ID given a valid state ID. We otherwise claim that
+// all other methods are correct as well.
+unsafe impl Automaton for NFA {
+    #[inline(always)]
+    fn start_state(&self, anchored: Anchored) -> Result<StateID, MatchError> {
+        match anchored {
+            Anchored::No => Ok(self.start_unanchored_id),
+            Anchored::Yes => Ok(self.start_anchored_id),
+        }
+    }
+
+    #[inline(always)]
+    fn next_state(
+        &self,
+        anchored: Anchored,
+        mut sid: StateID,
+        byte: u8,
+    ) -> StateID {
+        let table = &self.repr;
+        let class = self.byte_classes.get(byte) as u32;
+
+        loop {
+            let o = sid.as_usize();
+            let trans = &table[o + (class as usize) + 1];
+
+            if trans.offset() == class + 1 {
+                // Transition is valid
+                return trans.target_state();
+            }
+
+            // For an anchored search, we never follow failure transitions
+            // because failure transitions lead us down a path to matching
+            // a *proper* suffix of the path we were on. Thus, it can only
+            // produce matches that appear after the beginning of the search.
+            if anchored.is_anchored() {
+                return NFA::DEAD;
+            }
+
+            // Invalid transition, use the fail transition.
+            sid = table[o].target_state();
+        }
+    }
+
+    #[inline(always)]
+    fn is_special(&self, sid: StateID) -> bool {
+        self.is_dead(sid)
+            || self.is_match(sid)
+            || (self.prefilter.is_some() && self.is_start(sid))
+    }
+
+    #[inline(always)]
+    fn is_dead(&self, sid: StateID) -> bool {
+        sid == NFA::DEAD
+    }
+
+    #[inline(always)]
+    fn is_match(&self, sid: StateID) -> bool {
+        !self.matches[sid.as_usize()].is_empty()
+    }
+
+    #[inline(always)]
+    fn is_start(&self, sid: StateID) -> bool {
+        sid == self.start_unanchored_id || sid == self.start_anchored_id
+    }
+
+    #[inline(always)]
+    fn match_kind(&self) -> MatchKind {
+        self.match_kind
+    }
+
+    #[inline(always)]
+    fn patterns_len(&self) -> usize {
+        self.pattern_lens.len()
+    }
+
+    #[inline(always)]
+    fn pattern_len(&self, pid: PatternID) -> usize {
+        self.pattern_lens[pid].as_usize()
+    }
+
+    #[inline(always)]
+    fn min_pattern_len(&self) -> usize {
+        self.min_pattern_len
+    }
+
+    #[inline(always)]
+    fn max_pattern_len(&self) -> usize {
+        self.max_pattern_len
+    }
+
+    #[inline(always)]
+    fn match_len(&self, sid: StateID) -> usize {
+        self.matches[sid].len()
+    }
+
+    #[inline(always)]
+    fn match_pattern(&self, sid: StateID, index: usize) -> PatternID {
+        self.matches[sid][index]
+    }
+
+    #[inline(always)]
+    fn memory_usage(&self) -> usize {
+        use core::mem::size_of;
+
+        (self.repr.len() * size_of::<u32>())
+            + (self.matches.len() * size_of::<Vec<PatternID>>())
+            + self.matches_memory_usage
+            + (self.pattern_lens.len() * size_of::<SmallIndex>())
+            + self.prefilter.as_ref().map_or(0, |p| p.memory_usage())
+    }
+
+    #[inline(always)]
+    fn prefilter(&self) -> Option<&Prefilter> {
+        self.prefilter.as_ref()
+    }
+}
+
+impl core::fmt::Debug for NFA {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        use crate::automaton::fmt_state_indicator;
+
+        writeln!(f, "interleaved::NFA(")?;
+        for (index, trans) in self.repr.iter().enumerate() {
+            // The state "owning" this transition is the index minus the byteclass value.
+            let offset = trans.offset();
+            let source_sid = StateID::from_u32_unchecked(
+                (index - (trans.offset() as usize)) as u32,
+            );
+            let target_sid = trans.target_state();
+
+            fmt_state_indicator(f, self, source_sid)?;
+            if offset == 0 {
+                writeln!(
+                    f,
+                    "{:06}: {:06}({:06})",
+                    index,
+                    source_sid.as_usize(),
+                    target_sid.as_usize()
+                )?;
+
+                let patterns = &self.matches[source_sid];
+                if !patterns.is_empty() {
+                    write!(f, "         matches: ")?;
+                    for (i, pid) in patterns.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", pid.as_usize())?;
+                    }
+                    write!(f, "\n")?;
+                }
+            } else {
+                writeln!(
+                    f,
+                    "{:06}: {:06} + {:?} => {:06}",
+                    index,
+                    source_sid.as_usize(),
+                    DebugByte((offset - 1) as u8),
+                    target_sid.as_usize()
+                )?;
+            }
+        }
+        writeln!(f, "match kind: {:?}", self.match_kind)?;
+        writeln!(f, "prefilter: {:?}", self.prefilter.is_some())?;
+        writeln!(f, "state length: {:?}", self.state_len)?;
+        writeln!(f, "pattern length: {:?}", self.patterns_len())?;
+        writeln!(f, "shortest pattern length: {:?}", self.min_pattern_len)?;
+        writeln!(f, "longest pattern length: {:?}", self.max_pattern_len)?;
+        writeln!(
+            f,
+            "alphabet length: {:?}",
+            self.byte_classes.alphabet_len()
+        )?;
+        writeln!(f, "byte classes: {:?}", self.byte_classes)?;
+        writeln!(f, "memory usage: {:?}", self.memory_usage())?;
+        writeln!(f, ")")?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct Element(u32);
+
+impl Element {
+    /// An empty element. Holes in the table will have this value, which
+    /// always represents an invalid transition (except on state IDs indexes,
+    /// but those are filled with other values).
+    const EMPTY: Self = Self(0);
+
+    /// The stride to retrieve the state ID. 9 bits are reserved for the
+    /// offset.
+    const SID_STRIDE: u32 = 9;
+
+    /// Maximum sid storable.
+    const MAX_SID: u32 = u32::MAX >> Self::SID_STRIDE;
+
+    /// Build a new element.
+    ///
+    /// Fails if the state id overflows the maximum value storable.
+    fn new(sid: StateID, offset: u32) -> Result<Self, BuildError> {
+        let sid = sid.as_u32();
+
+        if sid > Self::MAX_SID {
+            Err(BuildError::state_id_overflow(
+                Self::MAX_SID as u64,
+                sid as u64,
+            ))
+        } else {
+            Ok(Self((sid << Self::SID_STRIDE) | offset))
+        }
+    }
+
+    /// Returns the offset of this transition
+    #[inline(always)]
+    fn offset(&self) -> u32 {
+        self.0 & ((1 << Self::SID_STRIDE) - 1)
+    }
+
+    /// Returns the target state ID for this transition
+    #[inline(always)]
+    fn target_state(&self) -> StateID {
+        StateID::from_u32_unchecked(self.0 >> Self::SID_STRIDE)
+    }
+}
+
+impl core::fmt::Debug for Element {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{:?} => {:?}",
+            self.offset(),
+            self.target_state().as_usize()
+        )
+    }
+}
+
+/// A builder for configuring an Aho-Corasick interleaved NFA.
+///
+/// This builder has a subset of the options available to a
+/// [`AhoCorasickBuilder`](crate::AhoCorasickBuilder). Of the shared options,
+/// their behavior is identical.
+#[derive(Clone, Debug)]
+pub struct Builder {
+    noncontiguous: noncontiguous::Builder,
+    byte_classes: bool,
+}
+
+impl Default for Builder {
+    fn default() -> Builder {
+        Builder {
+            noncontiguous: noncontiguous::Builder::new(),
+            byte_classes: true,
+        }
+    }
+}
+
+impl Builder {
+    /// Create a new builder for configuring an Aho-Corasick interleaved NFA.
+    pub fn new() -> Builder {
+        Builder::default()
+    }
+
+    /// Build an Aho-Corasick interleaved NFA from the given iterator of
+    /// patterns.
+    ///
+    /// A builder may be reused to create more NFAs.
+    pub fn build<I, P>(&self, patterns: I) -> Result<NFA, BuildError>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<[u8]>,
+    {
+        let nnfa = self.noncontiguous.build(patterns)?;
+        self.build_from_noncontiguous(&nnfa)
+    }
+
+    /// Build an Aho-Corasick interleaved NFA from the given noncontiguous NFA.
+    ///
+    /// Note that when this method is used, only the `byte_classes` settings
+    /// on this builder are respected. The other settings only apply to the
+    /// initial construction of the Aho-Corasick automaton. Since using this
+    /// method requires that initial construction has already completed, all
+    /// settings impacting only initial construction are no longer relevant.
+    pub fn build_from_noncontiguous(
+        &self,
+        nnfa: &noncontiguous::NFA,
+    ) -> Result<NFA, BuildError> {
+        debug!("building contiguous NFA");
+        let byte_classes = if self.byte_classes {
+            nnfa.byte_classes().clone()
+        } else {
+            ByteClasses::singletons()
+        };
+        let mut nfa = NFA {
+            repr: vec![],
+            matches: Vec::new(),
+            matches_memory_usage: 0,
+            pattern_lens: nnfa.pattern_lens_raw().to_vec(),
+            state_len: nnfa.states().len(),
+            prefilter: nnfa.prefilter().map(|p| p.clone()),
+            match_kind: nnfa.match_kind(),
+            byte_classes,
+            min_pattern_len: nnfa.min_pattern_len(),
+            max_pattern_len: nnfa.max_pattern_len(),
+            // This is set at the end.
+            start_unanchored_id: StateID::ZERO,
+            start_anchored_id: StateID::ZERO,
+        };
+        // Meat of the implementation: remap the state ids to interleave them in a much shorter
+        // vec.
+        let interleave_state = interleave(nnfa, &nfa.byte_classes)?;
+        // Create the table with these interleaved state ids.
+        nfa.build_table(nnfa, &interleave_state)?;
+
+        // Save matches details with the new state ids.
+        let remap = &interleave_state.index_to_state_id;
+        nfa.matches =
+            vec![Vec::new(); interleave_state.max_state_id.as_usize() + 1];
+        for (old_sid, state) in nnfa.states().iter().enumerate() {
+            if !state.matches.is_empty() {
+                nfa.matches[remap[old_sid]] = state.matches.clone();
+                nfa.matches_memory_usage +=
+                    std::mem::size_of::<PatternID>() * state.matches.len();
+            }
+        }
+
+        // Now that we've remapped all the IDs in our states, all that's left
+        // is remapping the special state IDs.
+        // Since this NFA version does not use ordering on states, we only really
+        // need the start ids, so just save thoses.
+        let old = nnfa.special();
+        nfa.start_unanchored_id = remap[old.start_unanchored_id];
+        nfa.start_anchored_id = remap[old.start_anchored_id];
+
+        debug!(
+            "interleaved NFA built, <states: {:?}, size: {:?}, \
+             alphabet len: {:?}>",
+            nfa.state_len,
+            nfa.memory_usage(),
+            nfa.byte_classes.alphabet_len(),
+        );
+        Ok(nfa)
+    }
+
+    /// Set the desired match semantics.
+    ///
+    /// This only applies when using [`Builder::build`] and not
+    /// [`Builder::build_from_noncontiguous`].
+    ///
+    /// See
+    /// [`AhoCorasickBuilder::match_kind`](crate::AhoCorasickBuilder::match_kind)
+    /// for more documentation and examples.
+    pub fn match_kind(&mut self, kind: MatchKind) -> &mut Builder {
+        self.noncontiguous.match_kind(kind);
+        self
+    }
+
+    /// Enable ASCII-aware case insensitive matching.
+    ///
+    /// This only applies when using [`Builder::build`] and not
+    /// [`Builder::build_from_noncontiguous`].
+    ///
+    /// See
+    /// [`AhoCorasickBuilder::ascii_case_insensitive`](crate::AhoCorasickBuilder::ascii_case_insensitive)
+    /// for more documentation and examples.
+    pub fn ascii_case_insensitive(&mut self, yes: bool) -> &mut Builder {
+        self.noncontiguous.ascii_case_insensitive(yes);
+        self
+    }
+
+    /// Enable heuristic prefilter optimizations.
+    ///
+    /// This only applies when using [`Builder::build`] and not
+    /// [`Builder::build_from_noncontiguous`].
+    ///
+    /// See
+    /// [`AhoCorasickBuilder::prefilter`](crate::AhoCorasickBuilder::prefilter)
+    /// for more documentation and examples.
+    pub fn prefilter(&mut self, yes: bool) -> &mut Builder {
+        self.noncontiguous.prefilter(yes);
+        self
+    }
+
+    /// Whether to attempt to shrink the size of the automaton's alphabet or
+    /// not.
+    ///
+    /// This should never be enabled unless you're debugging an automaton.
+    /// Namely, disabling byte classes makes transitions easier to reason
+    /// about, since they use the actual bytes instead of equivalence classes.
+    /// Disabling this confers no performance benefit at search time.
+    ///
+    /// See
+    /// [`AhoCorasickBuilder::byte_classes`](crate::AhoCorasickBuilder::byte_classes)
+    /// for more documentation and examples.
+    pub fn byte_classes(&mut self, yes: bool) -> &mut Builder {
+        self.byte_classes = yes;
+        self
+    }
+}
+
+/// Result of interleaving states
+struct InterleaveState {
+    /// Mapping from the old state ids to the new ones.
+    index_to_state_id: Vec<StateID>,
+
+    /// Largest new state id. Useful to allocate the right size
+    /// for the final table.
+    max_state_id: StateID,
+}
+
+/// Interleave states to reduce the size of the mapping and improve
+/// cache locality.
+///
+/// See documentation on [`NFA`] for more details.
+fn interleave(
+    nnfa: &noncontiguous::NFA,
+    byte_classes: &ByteClasses,
+) -> Result<InterleaveState, BuildError> {
+    // Map old state ids (indexes) to new ones
+    let mut index_to_state_id = vec![NFA::DEAD; nnfa.states().len()];
+    let mut max_state_id = NFA::DEAD;
+
+    // Indicates which indexes in the table are free.
+    let mut available_indexes = AvailableIndexes::default();
+
+    // Iterate of states in breadth-first iteration. This improves cache locality
+    // especially around the start state.
+    let mut states_to_add = VecDeque::new();
+    let mut visited = HashSet::with_capacity(nnfa.states().len());
+
+    // Dead state
+    states_to_add.push_back(StateID::from_u32_unchecked(0));
+    visited.insert(StateID::from_u32_unchecked(0));
+    // Fail state
+    states_to_add.push_back(StateID::from_u32_unchecked(1));
+    visited.insert(StateID::from_u32_unchecked(1));
+    // Starting states
+    states_to_add.push_back(nnfa.special().start_unanchored_id);
+    visited.insert(nnfa.special().start_unanchored_id);
+    states_to_add.push_back(nnfa.special().start_anchored_id);
+    visited.insert(nnfa.special().start_anchored_id);
+
+    while let Some(sid) = states_to_add.pop_front() {
+        let state = &nnfa.states()[sid];
+
+        // Search for an available place for this state.
+        let mut start_idx = available_indexes.first_available;
+        'OUTER: loop {
+            while available_indexes.used(start_idx) {
+                start_idx += 1;
+                continue;
+            }
+
+            for (byte, _) in &state.trans {
+                let class = byte_classes.get(*byte);
+                if available_indexes.used(start_idx + (class as usize) + 1) {
+                    start_idx += 1;
+                    continue 'OUTER;
+                }
+            }
+            break;
+        }
+
+        // An index to place this state has been found, save the new state id.
+        let new_sid = StateID::new(start_idx).map_err(|e| {
+            BuildError::state_id_overflow(StateID::MAX.as_u64(), e.attempted())
+        })?;
+        index_to_state_id[sid] = new_sid;
+        max_state_id = std::cmp::max(max_state_id, new_sid);
+
+        // Mark indexes that are now used.
+        available_indexes.mark_used(new_sid.as_usize());
+        for (byte, target_sid) in &state.trans {
+            let class = byte_classes.get(*byte);
+            let idx = new_sid.as_usize() + (class as usize) + 1;
+            available_indexes.mark_used(idx);
+            if visited.insert(*target_sid) {
+                states_to_add.push_back(*target_sid);
+            }
+        }
+    }
+
+    Ok(InterleaveState { index_to_state_id, max_state_id })
+}
+
+/// Helper to memorize which indexes in the final table are used.
+#[derive(Debug, Default)]
+struct AvailableIndexes {
+    used: Vec<bool>,
+    /// First index that is not used.
+    pub first_available: usize,
+}
+
+impl AvailableIndexes {
+    /// Returns whether an index in the table is already used.
+    pub fn used(&mut self, idx: usize) -> bool {
+        self.used.get(idx).copied().unwrap_or(false)
+    }
+
+    pub fn mark_used(&mut self, idx: usize) {
+        if idx >= self.used.len() {
+            self.used.resize(idx + 1, false);
+        }
+        self.used[idx] = true;
+        if idx == self.first_available {
+            self.first_available = self.used[idx..]
+                .iter()
+                .position(|v| !*v)
+                .map(|v| v + idx)
+                .unwrap_or_else(|| self.used.len());
+        }
+    }
+}

--- a/src/nfa/mod.rs
+++ b/src/nfa/mod.rs
@@ -37,4 +37,5 @@ would likely need to have hundreds of thousands or even millions of patterns
 before you hit this limit.)
 */
 pub mod contiguous;
+pub mod interleaved;
 pub mod noncontiguous;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -806,6 +806,32 @@ macro_rules! testcombo {
                 }
             );
             testconfig!(
+                nfa_interl_default,
+                $collection,
+                $kind,
+                |b: &mut AhoCorasickBuilder| {
+                    b.kind(Some(AhoCorasickKind::InterleavedNFA));
+                }
+            );
+            testconfig!(
+                nfa_interl_no_prefilter,
+                $collection,
+                $kind,
+                |b: &mut AhoCorasickBuilder| {
+                    b.kind(Some(AhoCorasickKind::InterleavedNFA))
+                        .prefilter(false);
+                }
+            );
+            testconfig!(
+                nfa_interl_no_byte_class,
+                $collection,
+                $kind,
+                |b: &mut AhoCorasickBuilder| {
+                    b.kind(Some(AhoCorasickKind::InterleavedNFA))
+                        .byte_classes(false);
+                }
+            );
+            testconfig!(
                 dfa_default,
                 $collection,
                 $kind,
@@ -936,6 +962,33 @@ testconfig!(
 );
 testconfig!(
     overlapping,
+    search_standard_overlapping_nfa_interl_default,
+    AC_STANDARD_OVERLAPPING,
+    Standard,
+    |b: &mut AhoCorasickBuilder| {
+        b.kind(Some(AhoCorasickKind::InterleavedNFA));
+    }
+);
+testconfig!(
+    overlapping,
+    search_standard_overlapping_nfa_interl_no_prefilter,
+    AC_STANDARD_OVERLAPPING,
+    Standard,
+    |b: &mut AhoCorasickBuilder| {
+        b.kind(Some(AhoCorasickKind::InterleavedNFA)).prefilter(false);
+    }
+);
+testconfig!(
+    overlapping,
+    search_standard_overlapping_nfa_interl_no_byte_class,
+    AC_STANDARD_OVERLAPPING,
+    Standard,
+    |b: &mut AhoCorasickBuilder| {
+        b.kind(Some(AhoCorasickKind::InterleavedNFA)).byte_classes(false);
+    }
+);
+testconfig!(
+    overlapping,
     search_standard_overlapping_dfa_default,
     AC_STANDARD_OVERLAPPING,
     Standard,
@@ -1027,6 +1080,16 @@ testconfig!(
 #[cfg(feature = "std")]
 testconfig!(
     stream,
+    search_standard_stream_nfa_interl_default,
+    AC_STANDARD_NON_OVERLAPPING,
+    Standard,
+    |b: &mut AhoCorasickBuilder| {
+        b.kind(Some(AhoCorasickKind::InterleavedNFA));
+    }
+);
+#[cfg(feature = "std")]
+testconfig!(
+    stream,
     search_standard_stream_dfa_default,
     AC_STANDARD_NON_OVERLAPPING,
     Standard,
@@ -1063,6 +1126,16 @@ testconfig!(
     |b: &mut AhoCorasickBuilder| {
         b.start_kind(StartKind::Anchored)
             .kind(Some(AhoCorasickKind::ContiguousNFA));
+    }
+);
+testconfig!(
+    anchored,
+    search_standard_anchored_nfa_interl_default,
+    AC_STANDARD_ANCHORED_NON_OVERLAPPING,
+    Standard,
+    |b: &mut AhoCorasickBuilder| {
+        b.start_kind(StartKind::Anchored)
+            .kind(Some(AhoCorasickKind::InterleavedNFA));
     }
 );
 testconfig!(
@@ -1114,6 +1187,16 @@ testconfig!(
 );
 testconfig!(
     anchored,
+    search_leftmost_first_anchored_nfa_interl_default,
+    AC_LEFTMOST_FIRST_ANCHORED,
+    LeftmostFirst,
+    |b: &mut AhoCorasickBuilder| {
+        b.start_kind(StartKind::Anchored)
+            .kind(Some(AhoCorasickKind::InterleavedNFA));
+    }
+);
+testconfig!(
+    anchored,
     search_leftmost_first_anchored_dfa_default,
     AC_LEFTMOST_FIRST_ANCHORED,
     LeftmostFirst,
@@ -1157,6 +1240,16 @@ testconfig!(
     |b: &mut AhoCorasickBuilder| {
         b.start_kind(StartKind::Anchored)
             .kind(Some(AhoCorasickKind::ContiguousNFA));
+    }
+);
+testconfig!(
+    anchored,
+    search_leftmost_longest_anchored_nfa_interl_default,
+    AC_LEFTMOST_LONGEST_ANCHORED,
+    LeftmostLongest,
+    |b: &mut AhoCorasickBuilder| {
+        b.start_kind(StartKind::Anchored)
+            .kind(Some(AhoCorasickKind::InterleavedNFA));
     }
 );
 testconfig!(
@@ -1208,6 +1301,16 @@ testconfig!(
     }
 );
 testconfig!(
+    acasei_standard_nfa_interl_default,
+    &[ASCII_CASE_INSENSITIVE],
+    Standard,
+    |b: &mut AhoCorasickBuilder| {
+        b.kind(Some(AhoCorasickKind::InterleavedNFA))
+            .prefilter(false)
+            .ascii_case_insensitive(true);
+    }
+);
+testconfig!(
     acasei_standard_dfa_default,
     &[ASCII_CASE_INSENSITIVE, ASCII_CASE_INSENSITIVE_NON_OVERLAPPING],
     Standard,
@@ -1241,6 +1344,16 @@ testconfig!(
     Standard,
     |b: &mut AhoCorasickBuilder| {
         b.kind(Some(AhoCorasickKind::ContiguousNFA))
+            .ascii_case_insensitive(true);
+    }
+);
+testconfig!(
+    overlapping,
+    acasei_standard_overlapping_nfa_interl_default,
+    &[ASCII_CASE_INSENSITIVE, ASCII_CASE_INSENSITIVE_OVERLAPPING],
+    Standard,
+    |b: &mut AhoCorasickBuilder| {
+        b.kind(Some(AhoCorasickKind::InterleavedNFA))
             .ascii_case_insensitive(true);
     }
 );
@@ -1280,6 +1393,15 @@ testconfig!(
     }
 );
 testconfig!(
+    acasei_leftmost_first_nfa_interl_default,
+    &[ASCII_CASE_INSENSITIVE, ASCII_CASE_INSENSITIVE_NON_OVERLAPPING],
+    LeftmostFirst,
+    |b: &mut AhoCorasickBuilder| {
+        b.kind(Some(AhoCorasickKind::InterleavedNFA))
+            .ascii_case_insensitive(true);
+    }
+);
+testconfig!(
     acasei_leftmost_first_dfa_default,
     &[ASCII_CASE_INSENSITIVE, ASCII_CASE_INSENSITIVE_NON_OVERLAPPING],
     LeftmostFirst,
@@ -1310,6 +1432,15 @@ testconfig!(
     LeftmostLongest,
     |b: &mut AhoCorasickBuilder| {
         b.kind(Some(AhoCorasickKind::ContiguousNFA))
+            .ascii_case_insensitive(true);
+    }
+);
+testconfig!(
+    acasei_leftmost_longest_nfa_interl_default,
+    &[ASCII_CASE_INSENSITIVE, ASCII_CASE_INSENSITIVE_NON_OVERLAPPING],
+    LeftmostLongest,
+    |b: &mut AhoCorasickBuilder| {
+        b.kind(Some(AhoCorasickKind::InterleavedNFA))
             .ascii_case_insensitive(true);
     }
 );
@@ -1472,6 +1603,13 @@ fn anchored_not_allowed_even_if_technically_available() {
         .unwrap();
     assert!(ac.try_find(Input::new("foo").anchored(Anchored::Yes)).is_err());
 
+    let ac = AhoCorasick::builder()
+        .kind(Some(AhoCorasickKind::InterleavedNFA))
+        .start_kind(StartKind::Unanchored)
+        .build(&["foo"])
+        .unwrap();
+    assert!(ac.try_find(Input::new("foo").anchored(Anchored::Yes)).is_err());
+
     // For completeness, check that the DFA returns an error too.
     let ac = AhoCorasick::builder()
         .kind(Some(AhoCorasickKind::DFA))
@@ -1496,6 +1634,13 @@ fn unanchored_not_allowed_even_if_technically_available() {
 
     let ac = AhoCorasick::builder()
         .kind(Some(AhoCorasickKind::ContiguousNFA))
+        .start_kind(StartKind::Anchored)
+        .build(&["foo"])
+        .unwrap();
+    assert!(ac.try_find(Input::new("foo").anchored(Anchored::No)).is_err());
+
+    let ac = AhoCorasick::builder()
+        .kind(Some(AhoCorasickKind::InterleavedNFA))
         .start_kind(StartKind::Anchored)
         .build(&["foo"])
         .unwrap();


### PR DESCRIPTION
This MR brings the implementation of another "NFA but optimized" automaton. This ones is greatly inspired from https://github.com/mischasan/aho-corasick (http://goo.gl/lE6zG), which i've seen being discussed not too long ago.

My use-case comes from https://github.com/vthib/boreal, and is mostly the same as the one from @plusvic (who might be interested in this MR for Yara-X as well): extract a bunch of literals from strings that are searched, and use a Aho-Corasick to match on those literals on a single pass against files that can tend to be quite big.

Using this awesome crate got me quite far, but investigating performances issues that I had when the number of literals gets big, I tried to implement this new NFA version to see if it brings good improvements.

Turns out, it does! When the number of literals gets quite big (around 5k on my computer, but I suppose this will depend on the processor's caches), this interleaved implementation is:
- much quicker to build compare to the DFA (build time stays close to the contiguous NFA)
- much smaller than the DFA
- can be faster than the DFA

A few examples that I have in my own benches are as follows:

13155 non-unique literals between 2 to 4 bytes long, against a 56MB file:
- DFA: build time ~3l4ms, count time ~320ms, automaton size: ~9.2MB
- Interleaved: build time ~27ms, count time ~270ms, automaton size: ~268KB
- contiguous: build time ~3.2ms, count time ~390ms, automaton size: ~3.1MB

31831 non-unique literals between 2 to 4 bytes long, against a 56MB file:
- DFA: build time ~260ms, count time ~671ms, automaton size: ~36MB
- Interleaved: build time ~13ms, count time ~290ms, automaton size: ~981KB
- contiguous: build time ~10ms, count time ~420ms, automaton size: ~7MB

This however can vary quite a bit. When comparing performances on a 150MB file with the same literals with `aho-corasick-debug` I have the DFA faster that the interleaved implementation, but when doing the exact same scanning, but inside my own project, performances are relatively similar. I haven't profiled much to understand what is going on exactly.

When the number of literals is not that high however, it tends to do much worst than the DFA, and be very similar to the contiguous NFA implementation, with a smaller memory footprint, but generally longer build times.

The other drawback is the same as the one for the contiguous implementation, limitation on the number of states that can be used. The max state id is 2**23-1, but given how the automaton size manages to stay quite small, this may still work for a quite large number of patterns.

Let me know if you are interested in this, I do not know if you are interested in adding more implementations. I think the performances are very interesting and would be very useful in some usecases such as mine, where i'll probably go for a DFA when the number of patterns is small, then use an interleaved NFA when it gets bigger. The very small memory footprint could also be useful for some people that may care more about a limited memory footprint than a as fast as possible scan time.

There may be adjustments to make. I've used a HashSet in the implementation which i'm not sure are desirable or not, and there may be a few other things to improve. I don't think I perfectly understood how the "NFA::FAIL" state works, and there should be improvements to make related to it.

I've tried to document as much as possible how it works, implementation is definitely not trivial and i've got quite a few difficulties when trying to understand how the original C implementation works. Making it fit the ordering of states for fast "is_special" or "is_match" calls was also non trivial, as it didn't really fit the design of the original paper.

I've also added a bench to show a bit how this implementation shines. All of the other benches tend to work on rather small numbers of patterns, where this implementation is often much worse than others, apart from the automaton size.

Also, i'd like to thank you for your work on this. I've been able to use this crate for quite some time and benefit from its nice design and performances without any work from my part. But getting into its codebase to see if I could add the interleaved design, I was amazed by the quality of the code and the documentation throughout the whole codebase. I don't think it's an exageration to say this is probably the most well documented and cleanest code i've ever read! Understanding how the crate works, adding a new implementation, testing and debugging it was made very easy. So thank you :)
