### PR TITLE
1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aho-corasick"
-version = "0.7.20"  #:version
+version = "1.0.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Fast multiple substring searching."
 homepage = "https://github.com/BurntSushi/aho-corasick"

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ expression alternation. See `MatchKind` in the docs for more details.
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.56.1`.
+This crate's minimum supported `rustc` version is `1.60.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires


### PR DESCRIPTION
Brief changelog from the `0.7.x` version:

* A new crate feature, `std`, has been added and is enabled by default. This makes the standard library optional and permits using `aho-corasick` in core/alloc-only contexts. But you do need `alloc`.
* The top-level `AhoCorasick` will mostly behave the same as before. `AhoCorasick::new` is now fallible. The type is no longer generic. (In `0.7.x`, you can choose the size of the state ID to use, but I did away with this and now just use `u32` everywhere.)
* APIs like `AhoCorasick::find` now accept an `impl Into<Input>`, where an `Input` provides a way to configure a search. There is an `impl From<H: AsRef<[u8]>> for Input`, so you can still call `find` with types like `&str` and `&[u8]`. But `Input` lets you set the bounds of the search, run an anchored search and so on. In 0.7, for example, in order to run an anchored search you had to configure it as a build-time parameter of the `AhoCorasick` automaton.
* An `AhoCorasick` type can now be configured to support unanchored and anchored searches simultaneously using `StartKind`. It defaults to just unanchored searches.
* The `supports_overlapping` and `supports_stream` routines were removed in favor of `try_*` search APIs. I could add the predicates back if needed, but they were principally useful to be able to guarantee that panics didn't happen when you called a search API with an unsupported configuration. But now there are fallible APIs for that.
* There are three new sub-modules, `automaton`, `dfa` and `nfa`. These provide low level access to different types of Aho-Corasick automata, and are not expected to be used for most use cases. The key thing they unlock, by implementing the `automaton::Automaton` trait, is the ability to walk the automaton one state at a time. For example, you can now write your own search routines. This might unlock more interesting streaming use cases.
* The `packed` submodule remains largely unchanged.
* Increases the MSRV to Rust 1.60.0.

Closes #101, Closes #108