### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ all-features = true
 # To test this locally, run:
 #
 #     RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [profile.release]
 debug = true


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).