### PR TITLE
reduce memory usage by over 50% by refactoring the non-contiguous NFA representation

### DIFF
--- a/aho-corasick-debug/main.rs
+++ b/aho-corasick-debug/main.rs
@@ -87,7 +87,7 @@ impl Args {
             .arg(
                 Arg::with_name("dense-depth")
                     .long("dense-depth")
-                    .default_value("2"),
+                    .default_value("3"),
             )
             .arg(
                 Arg::with_name("no-prefilter").long("no-prefilter").short("f"),

--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -1996,7 +1996,7 @@ impl AhoCorasick {
     ///     .ascii_case_insensitive(true)
     ///     .build(&["foobar", "bruce", "triskaidekaphobia", "springsteen"])
     ///     .unwrap();
-    /// assert_eq!(9_144, ac.memory_usage());
+    /// assert_eq!(6_630, ac.memory_usage());
     ///
     /// let ac = AhoCorasick::builder()
     ///     .kind(Some(AhoCorasickKind::ContiguousNFA))

--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -1996,7 +1996,7 @@ impl AhoCorasick {
     ///     .ascii_case_insensitive(true)
     ///     .build(&["foobar", "bruce", "triskaidekaphobia", "springsteen"])
     ///     .unwrap();
-    /// assert_eq!(6_630, ac.memory_usage());
+    /// assert_eq!(10_879, ac.memory_usage());
     ///
     /// let ac = AhoCorasick::builder()
     ///     .kind(Some(AhoCorasickKind::ContiguousNFA))
@@ -2579,6 +2579,7 @@ impl AhoCorasickBuilder {
     /// More to the point, the memory usage increases superlinearly as this
     /// number increases.
     pub fn dense_depth(&mut self, depth: usize) -> &mut AhoCorasickBuilder {
+        self.nfa_noncontiguous.dense_depth(depth);
         self.nfa_contiguous.dense_depth(depth);
         self
     }

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -168,13 +168,21 @@ impl DFA {
 
     /// Adds the given pattern IDs as matches to the given state and also
     /// records the added memory usage.
-    fn set_matches(&mut self, sid: StateID, pids: &[PatternID]) {
+    fn set_matches(
+        &mut self,
+        sid: StateID,
+        pids: impl Iterator<Item = PatternID>,
+    ) {
         use core::mem::size_of;
 
-        assert!(!pids.is_empty(), "match state must have non-empty pids");
         let index = (sid.as_usize() >> self.stride2).checked_sub(2).unwrap();
-        self.matches[index].extend_from_slice(pids);
-        self.matches_memory_usage += size_of::<PatternID>() * pids.len();
+        let mut at_least_one = false;
+        for pid in pids {
+            self.matches[index].push(pid);
+            self.matches_memory_usage += PatternID::SIZE;
+            at_least_one = true;
+        }
+        assert!(at_least_one, "match state must have non-empty pids");
     }
 }
 
@@ -549,11 +557,12 @@ impl Builder {
         };
         for (oldsid, state) in nnfa.states().iter().with_state_ids() {
             let newsid = old2new(oldsid);
-            if !state.matches.is_empty() {
-                dfa.set_matches(newsid, &state.matches);
+            if state.is_match() {
+                dfa.set_matches(newsid, nnfa.iter_matches(oldsid));
             }
             sparse_iter(
-                state,
+                nnfa,
+                oldsid,
                 &dfa.byte_classes,
                 |byte, class, mut oldnextsid| {
                     if oldnextsid == noncontiguous::NFA::FAIL {
@@ -562,7 +571,7 @@ impl Builder {
                         } else {
                             oldnextsid = nnfa.next_state(
                                 Anchored::No,
-                                state.fail,
+                                state.fail(),
                                 byte,
                             );
                         }
@@ -626,11 +635,12 @@ impl Builder {
                     remap_anchored[oldsid] = newsid;
                     is_anchored[newsid.as_usize() >> stride2] = true;
                 }
-                if !state.matches.is_empty() {
-                    dfa.set_matches(newsid, &state.matches);
+                if state.is_match() {
+                    dfa.set_matches(newsid, nnfa.iter_matches(oldsid));
                 }
                 sparse_iter(
-                    state,
+                    nnfa,
+                    oldsid,
                     &dfa.byte_classes,
                     |_, class, oldnextsid| {
                         let class = usize::from(class);
@@ -651,18 +661,19 @@ impl Builder {
                 remap_unanchored[oldsid] = unewsid;
                 remap_anchored[oldsid] = anewsid;
                 is_anchored[anewsid.as_usize() >> stride2] = true;
-                if !state.matches.is_empty() {
-                    dfa.set_matches(unewsid, &state.matches);
-                    dfa.set_matches(anewsid, &state.matches);
+                if state.is_match() {
+                    dfa.set_matches(unewsid, nnfa.iter_matches(oldsid));
+                    dfa.set_matches(anewsid, nnfa.iter_matches(oldsid));
                 }
                 sparse_iter(
-                    state,
+                    nnfa,
+                    oldsid,
                     &dfa.byte_classes,
                     |byte, class, oldnextsid| {
                         let class = usize::from(class);
                         if oldnextsid == noncontiguous::NFA::FAIL {
                             dfa.trans[unewsid.as_usize() + class] = nnfa
-                                .next_state(Anchored::No, state.fail, byte);
+                                .next_state(Anchored::No, state.fail(), byte);
                         } else {
                             dfa.trans[unewsid.as_usize() + class] = oldnextsid;
                             dfa.trans[anewsid.as_usize() + class] = oldnextsid;
@@ -769,14 +780,15 @@ impl Builder {
 /// `byte_classes.alphabet_len()` times, once for every possible class in
 /// ascending order.
 fn sparse_iter<F: FnMut(u8, u8, StateID)>(
-    state: &noncontiguous::State,
+    nnfa: &noncontiguous::NFA,
+    oldsid: StateID,
     classes: &ByteClasses,
     mut f: F,
 ) {
     let mut prev_class = None;
     let mut byte = 0usize;
-    for &(b, id) in state.trans.iter() {
-        while byte < usize::from(b) {
+    for t in nnfa.iter_trans(oldsid) {
+        while byte < usize::from(t.byte()) {
             let rep = byte.as_u8();
             let class = classes.get(rep);
             byte += 1;
@@ -785,11 +797,11 @@ fn sparse_iter<F: FnMut(u8, u8, StateID)>(
                 prev_class = Some(class);
             }
         }
-        let rep = b;
+        let rep = t.byte();
         let class = classes.get(rep);
         byte += 1;
         if prev_class != Some(class) {
-            f(rep, class, id);
+            f(rep, class, t.next());
             prev_class = Some(class);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,7 @@ this crate can be used without the standard library.
   diagnostics. This feature is disabled by default.
 */
 
+#![allow(warnings)]
 #![no_std]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/src/nfa/contiguous.rs
+++ b/src/nfa/contiguous.rs
@@ -684,6 +684,8 @@ impl<'a> State<'a> {
     /// dense format. Otherwise, the choice between dense and sparse will be
     /// automatically chosen based on the old state.
     fn write(
+        nnfa: &noncontiguous::NFA,
+        oldsid: StateID,
         old: &noncontiguous::State,
         classes: &ByteClasses,
         dst: &mut Vec<u32>,
@@ -692,45 +694,46 @@ impl<'a> State<'a> {
         let sid = StateID::new(dst.len()).map_err(|e| {
             BuildError::state_id_overflow(StateID::MAX.as_u64(), e.attempted())
         })?;
+        let old_len = nnfa.iter_trans(oldsid).count();
         // For states with a lot of transitions, we might as well just make
         // them dense. These kinds of hot states tend to be very rare, so we're
         // okay with it. This also gives us more sentinels in the state's
         // 'kind', which lets us create different state kinds to save on
         // space.
-        let kind = if force_dense
-            || old.trans.len() > State::MAX_SPARSE_TRANSITIONS
-        {
+        let kind = if force_dense || old_len > State::MAX_SPARSE_TRANSITIONS {
             State::KIND_DENSE
-        } else if old.trans.len() == 1 && old.matches.is_empty() {
+        } else if old_len == 1 && !old.is_match() {
             State::KIND_ONE
         } else {
             // For a sparse state, the kind is just the number of transitions.
-            u32::try_from(old.trans.len()).unwrap()
+            u32::try_from(old_len).unwrap()
         };
         if kind == State::KIND_DENSE {
             dst.push(kind);
-            dst.push(old.fail.as_u32());
-            State::write_dense_trans(old, classes, dst)?;
+            dst.push(old.fail().as_u32());
+            State::write_dense_trans(nnfa, oldsid, classes, dst)?;
         } else if kind == State::KIND_ONE {
-            let class = u32::from(classes.get(old.trans[0].0));
+            let t = nnfa.iter_trans(oldsid).next().unwrap();
+            let class = u32::from(classes.get(t.byte()));
             dst.push(kind | (class << 8));
-            dst.push(old.fail.as_u32());
-            dst.push(old.trans[0].1.as_u32());
+            dst.push(old.fail().as_u32());
+            dst.push(t.next().as_u32());
         } else {
             dst.push(kind);
-            dst.push(old.fail.as_u32());
-            State::write_sparse_trans(old, classes, dst)?;
+            dst.push(old.fail().as_u32());
+            State::write_sparse_trans(nnfa, oldsid, classes, dst)?;
         }
         // Now finally write the number of matches and the matches themselves.
-        if !old.matches.is_empty() {
-            if old.matches.len() == 1 {
-                let pid = old.matches[0].as_u32();
+        if old.is_match() {
+            let matches_len = nnfa.iter_matches(oldsid).count();
+            if matches_len == 1 {
+                let pid = nnfa.iter_matches(oldsid).next().unwrap().as_u32();
                 assert_eq!(0, pid & (1 << 31));
                 dst.push((1 << 31) | pid);
             } else {
-                assert_eq!(0, old.matches.len() & (1 << 31));
-                dst.push(old.matches.len().as_u32());
-                dst.extend(old.matches.iter().map(|pid| pid.as_u32()));
+                assert_eq!(0, matches_len & (1 << 31));
+                dst.push(matches_len.as_u32());
+                dst.extend(nnfa.iter_matches(oldsid).map(|pid| pid.as_u32()));
             }
         }
         Ok(sid)
@@ -744,13 +747,14 @@ impl<'a> State<'a> {
     /// This returns an error if `dst` became so big that `StateID`s can no
     /// longer be created for new states.
     fn write_sparse_trans(
-        old: &noncontiguous::State,
+        nnfa: &noncontiguous::NFA,
+        oldsid: StateID,
         classes: &ByteClasses,
         dst: &mut Vec<u32>,
     ) -> Result<(), BuildError> {
         let (mut chunk, mut len) = ([0; 4], 0);
-        for &(byte, _) in old.trans.iter() {
-            chunk[len] = classes.get(byte);
+        for t in nnfa.iter_trans(oldsid) {
+            chunk[len] = classes.get(t.byte());
             len += 1;
             if len == 4 {
                 dst.push(u32::from_ne_bytes(chunk));
@@ -773,8 +777,8 @@ impl<'a> State<'a> {
             }
             dst.push(u32::from_ne_bytes(chunk));
         }
-        for &(_, next) in old.trans.iter() {
-            dst.push(next.as_u32());
+        for t in nnfa.iter_trans(oldsid) {
+            dst.push(t.next().as_u32());
         }
         Ok(())
     }
@@ -787,7 +791,8 @@ impl<'a> State<'a> {
     /// This returns an error if `dst` became so big that `StateID`s can no
     /// longer be created for new states.
     fn write_dense_trans(
-        old: &noncontiguous::State,
+        nnfa: &noncontiguous::NFA,
+        oldsid: StateID,
         classes: &ByteClasses,
         dst: &mut Vec<u32>,
     ) -> Result<(), BuildError> {
@@ -807,8 +812,9 @@ impl<'a> State<'a> {
                 .take(classes.alphabet_len()),
         );
         assert!(start < dst.len(), "equivalence classes are never empty");
-        for &(byte, next) in old.trans.iter() {
-            dst[start + usize::from(classes.get(byte))] = next.as_u32();
+        for t in nnfa.iter_trans(oldsid) {
+            dst[start + usize::from(classes.get(t.byte()))] =
+                t.next().as_u32();
         }
         Ok(())
     }
@@ -960,8 +966,10 @@ impl Builder {
                 index_to_state_id[oldsid] = NFA::FAIL;
                 continue;
             }
-            let force_dense = state.depth.as_usize() < self.dense_depth;
+            let force_dense = state.depth().as_usize() < self.dense_depth;
             let newsid = State::write(
+                nnfa,
+                oldsid,
                 state,
                 &nfa.byte_classes,
                 &mut nfa.repr,

--- a/src/nfa/noncontiguous.rs
+++ b/src/nfa/noncontiguous.rs
@@ -508,6 +508,7 @@ impl State {
 
 /// A single transition in a non-contiguous NFA.
 #[derive(Clone, Copy, Debug)]
+#[repr(packed)]
 pub(crate) struct Transition {
     byte: u8,
     next: StateID,


### PR DESCRIPTION
In effect, we switch to using a linked list to represent transitions for each state in a non-contiguous NFA. (The commit messages have more details.) This substantially reduces memory usage and means that overall peak memory usage is reduced as well when building things like a contiguous NFA.

I'll show a couple examples. This first one comes from [this issue](). There's 300,000 patterns and each pattern is comprised of 4 random words:

```
$ time aho-corasick-debug_2023-08-10-before-noncontiguous-refactor /tmp/300000.pats /tmp/haystack.small --match-kind standard --kind noncontiguous
pattern read time: 2.690752ms
automaton build time: 2.135668194s
automaton heap usage: 561774264 bytes
match count: 1
count time: 3.538399241s

real    5.761
user    5.551
sys     0.207
maxmem  1006 MB
faults  0

$ time aho-corasick-debug /tmp/300000.pats /tmp/haystack.small --match-kind standard --kind noncontiguous
pattern read time: 2.672161ms
automaton build time: 1.439117348s
automaton heap usage: 259695786 bytes
match count: 1
count time: 2.684963216s

real    4.133
user    4.081
sys     0.050
maxmem  390 MB
faults  0
```

This gives us a 50% reduction in the heap used by the non-contigous NFA and an even greater reduction in peak memory usage. Plus, search times get faster!

The next test is one of my standard go-tos that builds an automaton from 1,000,000 randomly selected Wikipedia article titles:

```
$ time aho-corasick-debug_2023-08-10-before-noncontiguous-refactor ~/data/benchsuite/texts/wikipedia/titles.1000000 /tmp/haystack.small --match-kind standard --kind noncontiguous
pattern read time: 7.727681ms
automaton build time: 3.086064908s
automaton heap usage: 832984632 bytes
match count: 1117113
count time: 1.250706555s

real    4.503
user    4.287
sys     0.213
maxmem  1421 MB
faults  0

$ time aho-corasick-debug ~/data/benchsuite/texts/wikipedia/titles.1000000 /tmp/haystack.small --match-kind standard --kind noncontiguous
pattern read time: 7.849024ms
automaton build time: 3.212135732s
automaton heap usage: 413686502 bytes
match count: 1117113
count time: 1.209295572s

real    4.437
user    4.358
sys     0.077
maxmem  538 MB
faults  0
```

Search times remain roughly the same, but heap used by the NFA and peak memory usage decrease substantially, in similar ratios as the previous test.

Much thanks to https://github.com/G-Research/ahocorasick_rs/issues/62 and @erikcw for the kick in the ass to explore this idea.