### PR TITLE
Add a link to tmikus/ahocorasick_rs to the README.md - a Go wrapper for this library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,5 @@ supported version of Rust.
 
 * [G-Research/ahocorasick_rs](https://github.com/G-Research/ahocorasick_rs/)
 is a Python wrapper for this library.
+* [tmikus/ahocorasick_rs](https://github.com/tmikus/ahocorasick_rs) is a Go
+    wrapper for this library.


### PR DESCRIPTION
This commit addresses #125

Are you fine with this kind of section, or should I rename it to something else?