### PR TITLE
Make this build on aarch64_be as well.

### DIFF
--- a/src/packed/teddy/builder.rs
+++ b/src/packed/teddy/builder.rs
@@ -230,7 +230,7 @@ impl Builder {
                 }
             }
         }
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon", target_endian = "little"))]
         {
             use self::aarch64::SlimNeon;
 
@@ -301,7 +301,7 @@ impl Builder {
         }
         #[cfg(not(any(
             all(target_arch = "x86_64", target_feature = "sse2"),
-            target_arch = "aarch64"
+            all(target_arch = "aarch64", target_feature = "neon", target_endian = "little")
         )))]
         {
             None
@@ -705,7 +705,7 @@ mod x86_64 {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon", target_endian = "little"))]
 mod aarch64 {
     use core::arch::aarch64::uint8x16_t;
 

--- a/src/packed/teddy/builder.rs
+++ b/src/packed/teddy/builder.rs
@@ -230,7 +230,11 @@ impl Builder {
                 }
             }
         }
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon", target_endian = "little"))]
+        #[cfg(all(
+            target_arch = "aarch64",
+            target_feature = "neon",
+            target_endian = "little"
+        ))]
         {
             use self::aarch64::SlimNeon;
 
@@ -301,7 +305,11 @@ impl Builder {
         }
         #[cfg(not(any(
             all(target_arch = "x86_64", target_feature = "sse2"),
-            all(target_arch = "aarch64", target_feature = "neon", target_endian = "little")
+            all(
+                target_arch = "aarch64",
+                target_feature = "neon",
+                target_endian = "little"
+            )
         )))]
         {
             None
@@ -705,7 +713,11 @@ mod x86_64 {
     }
 }
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon", target_endian = "little"))]
+#[cfg(all(
+    target_arch = "aarch64",
+    target_feature = "neon",
+    target_endian = "little"
+))]
 mod aarch64 {
     use core::arch::aarch64::uint8x16_t;
 

--- a/src/packed/vector.rs
+++ b/src/packed/vector.rs
@@ -595,7 +595,7 @@ mod x86_64_avx2 {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon", target_endian = "little"))]
 mod aarch64_neon {
     use core::arch::aarch64::*;
 

--- a/src/packed/vector.rs
+++ b/src/packed/vector.rs
@@ -595,7 +595,11 @@ mod x86_64_avx2 {
     }
 }
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon", target_endian = "little"))]
+#[cfg(all(
+    target_arch = "aarch64",
+    target_feature = "neon",
+    target_endian = "little"
+))]
 mod aarch64_neon {
     use core::arch::aarch64::*;
 


### PR DESCRIPTION
If I've understood correctly, the "neon" feature is not available in big-endian mode on aarch64.  Despite this, I need to test for both "neon" feature and endian-ness to make this build.