### PR TITLE
Implement serde, but with prefilter disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aho-corasick"
-version = "1.1.3"  #:version
+version = "1.1.3"                                           #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Fast multiple substring searching."
 homepage = "https://github.com/BurntSushi/aho-corasick"
@@ -47,12 +47,16 @@ logging = ["dep:log"]
 # there. But I haven't gotten around to it yet.
 # transducer = ["fst"]
 
+serde = ["std", "dep:serde"]
+
 [dependencies]
 log = { version = "0.4.17", optional = true }
 memchr = { version = "2.4.0", default-features = false, optional = true }
+serde = { version = "1.0.203", features = ["derive"], optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3.3"
+sonic-rs = "0.3.7"
 # fst = "0.4.5"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "1.0.203", features = ["derive"], optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3.3"
-sonic-rs = "0.3.7"
+rmp-serde = "1.3.0"
 # fst = "0.4.5"
 
 [package.metadata.docs.rs]

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -8,6 +8,8 @@ when one needs access to the [`Automaton`] trait implementation.
 */
 
 use alloc::{vec, vec::Vec};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     automaton::Automaton,
@@ -88,6 +90,7 @@ use crate::{
 /// It is also possible to implement your own version of `try_find`. See the
 /// [`Automaton`] documentation for an example.
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DFA {
     /// The DFA transition table. IDs in this table are pre-multiplied. So
     /// instead of the IDs being 0, 1, 2, 3, ..., they are 0*stride, 1*stride,
@@ -104,6 +107,7 @@ pub struct DFA {
     /// of a match.
     pattern_lens: Vec<SmallIndex>,
     /// A prefilter for accelerating searches, if one exists.
+    #[cfg_attr(feature = "serde", serde(skip))]
     prefilter: Option<Prefilter>,
     /// The match semantics built into this DFA.
     match_kind: MatchKind,

--- a/src/nfa/contiguous.rs
+++ b/src/nfa/contiguous.rs
@@ -8,6 +8,8 @@ necessary when one needs access to the [`Automaton`] trait implementation.
 */
 
 use alloc::{vec, vec::Vec};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     automaton::Automaton,
@@ -88,6 +90,7 @@ use crate::{
 /// It is also possible to implement your own version of `try_find`. See the
 /// [`Automaton`] documentation for an example.
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NFA {
     /// The raw NFA representation. Each state is packed with a header
     /// (containing the format of the state, the failure transition and, for
@@ -100,6 +103,7 @@ pub struct NFA {
     /// The total number of states in this NFA.
     state_len: usize,
     /// A prefilter for accelerating searches, if one exists.
+    #[cfg_attr(feature = "serde", serde(skip))]
     prefilter: Option<Prefilter>,
     /// The match semantics built into this NFA.
     match_kind: MatchKind,

--- a/src/nfa/noncontiguous.rs
+++ b/src/nfa/noncontiguous.rs
@@ -12,6 +12,8 @@ use alloc::{
     vec,
     vec::Vec,
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     automaton::Automaton,
@@ -79,6 +81,7 @@ use crate::{
 /// It is also possible to implement your own version of `try_find`. See the
 /// [`Automaton`] documentation for an example.
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NFA {
     /// The match semantics built into this NFA.
     match_kind: MatchKind,
@@ -139,6 +142,7 @@ pub struct NFA {
     /// patterns in this automaton.
     pattern_lens: Vec<SmallIndex>,
     /// A prefilter for quickly skipping to candidate matches, if pertinent.
+    #[cfg_attr(feature = "serde", serde(skip))]
     prefilter: Option<Prefilter>,
     /// A set of equivalence classes in terms of bytes. We compute this while
     /// building the NFA, but don't use it in the NFA's states. Instead, we
@@ -707,6 +711,7 @@ unsafe impl Automaton for NFA {
 /// cases where there exists no other transition for the current input byte
 /// and the matches implied by visiting this state (if any).
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub(crate) struct State {
     /// A pointer to `NFA::trans` corresponding to the head of a linked list
     /// containing all of the transitions for this state.
@@ -767,6 +772,7 @@ impl State {
 
 /// A single transition in a non-contiguous NFA.
 #[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(packed)]
 pub(crate) struct Transition {
     byte: u8,
@@ -805,6 +811,7 @@ impl core::fmt::Debug for Transition {
 
 /// A single match in a non-contiguous NFA.
 #[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct Match {
     pid: PatternID,
     link: StateID,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -676,7 +676,7 @@ macro_rules! testconfig {
                     .prefilter(false)
                     .build(test.patterns)
                     .unwrap();
-                let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
+                let ac_bytes = rmp_serde::to_vec_named(&ac).unwrap();
                 let ac: AhoCorasick =
                     rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.try_find_iter(input).unwrap().collect()
@@ -705,7 +705,7 @@ macro_rules! testconfig {
                     .prefilter(false)
                     .build(test.patterns)
                     .unwrap();
-                let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
+                let ac_bytes = rmp_serde::to_vec_named(&ac).unwrap();
                 let ac: AhoCorasick =
                     rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.find_overlapping_iter(test.haystack).collect()
@@ -743,7 +743,7 @@ macro_rules! testconfig {
                     .prefilter(false)
                     .build(test.patterns)
                     .unwrap();
-                let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
+                let ac_bytes = rmp_serde::to_vec_named(&ac).unwrap();
                 let ac: AhoCorasick =
                     rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.stream_find_iter(buf)
@@ -774,7 +774,7 @@ macro_rules! testconfig {
                     .prefilter(false)
                     .build(test.patterns)
                     .unwrap();
-                let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
+                let ac_bytes = rmp_serde::to_vec_named(&ac).unwrap();
                 let ac: AhoCorasick =
                     rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.find_iter(test.haystack).collect()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -666,6 +666,20 @@ macro_rules! testconfig {
                     .unwrap()
                     .collect()
             });
+            #[cfg(feature = "serde")]
+            run_search_tests($collection, |test| {
+                let mut builder = AhoCorasick::builder();
+                $with(&mut builder);
+                let input = Input::new(test.haystack).anchored(Anchored::Yes);
+                let ac = builder
+                    .match_kind(MatchKind::$kind)
+                    .prefilter(false)
+                    .build(test.patterns)
+                    .unwrap();
+                let ac_bytes = sonic_rs::to_string(&ac).unwrap();
+                let ac: AhoCorasick = sonic_rs::from_str(&ac_bytes).unwrap();
+                ac.try_find_iter(input).unwrap().collect()
+            });
         }
     };
     (overlapping, $name:ident, $collection:expr, $kind:ident, $with:expr) => {
@@ -680,6 +694,19 @@ macro_rules! testconfig {
                     .unwrap()
                     .find_overlapping_iter(test.haystack)
                     .collect()
+            });
+            #[cfg(feature = "serde")]
+            run_search_tests($collection, |test| {
+                let mut builder = AhoCorasick::builder();
+                $with(&mut builder);
+                let ac = builder
+                    .match_kind(MatchKind::$kind)
+                    .prefilter(false)
+                    .build(test.patterns)
+                    .unwrap();
+                let ac_bytes = sonic_rs::to_string(&ac).unwrap();
+                let ac: AhoCorasick = sonic_rs::from_str(&ac_bytes).unwrap();
+                ac.find_overlapping_iter(test.haystack).collect()
             });
         }
     };
@@ -701,6 +728,25 @@ macro_rules! testconfig {
                     .map(|result| result.unwrap())
                     .collect()
             });
+            #[cfg(feature = "serde")]
+            run_stream_search_tests($collection, |test| {
+                let buf = std::io::BufReader::with_capacity(
+                    1,
+                    test.haystack.as_bytes(),
+                );
+                let mut builder = AhoCorasick::builder();
+                $with(&mut builder);
+                let ac = builder
+                    .match_kind(MatchKind::$kind)
+                    .prefilter(false)
+                    .build(test.patterns)
+                    .unwrap();
+                let ac_bytes = sonic_rs::to_string(&ac).unwrap();
+                let ac: AhoCorasick = sonic_rs::from_str(&ac_bytes).unwrap();
+                ac.stream_find_iter(buf)
+                    .map(|result| result.unwrap())
+                    .collect()
+            });
         }
     };
     ($name:ident, $collection:expr, $kind:ident, $with:expr) => {
@@ -715,6 +761,19 @@ macro_rules! testconfig {
                     .unwrap()
                     .find_iter(test.haystack)
                     .collect()
+            });
+            #[cfg(feature = "serde")]
+            run_search_tests($collection, |test| {
+                let mut builder = AhoCorasick::builder();
+                $with(&mut builder);
+                let ac = builder
+                    .match_kind(MatchKind::$kind)
+                    .prefilter(false)
+                    .build(test.patterns)
+                    .unwrap();
+                let ac_bytes = sonic_rs::to_string(&ac).unwrap();
+                let ac: AhoCorasick = sonic_rs::from_str(&ac_bytes).unwrap();
+                ac.find_iter(test.haystack).collect()
             });
         }
     };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -676,8 +676,8 @@ macro_rules! testconfig {
                     .prefilter(false)
                     .build(test.patterns)
                     .unwrap();
-                let ac_bytes = sonic_rs::to_string(&ac).unwrap();
-                let ac: AhoCorasick = sonic_rs::from_str(&ac_bytes).unwrap();
+                let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
+                let ac: AhoCorasick = rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.try_find_iter(input).unwrap().collect()
             });
         }
@@ -704,8 +704,8 @@ macro_rules! testconfig {
                     .prefilter(false)
                     .build(test.patterns)
                     .unwrap();
-                let ac_bytes = sonic_rs::to_string(&ac).unwrap();
-                let ac: AhoCorasick = sonic_rs::from_str(&ac_bytes).unwrap();
+                let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
+                let ac: AhoCorasick = rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.find_overlapping_iter(test.haystack).collect()
             });
         }
@@ -741,8 +741,8 @@ macro_rules! testconfig {
                     .prefilter(false)
                     .build(test.patterns)
                     .unwrap();
-                let ac_bytes = sonic_rs::to_string(&ac).unwrap();
-                let ac: AhoCorasick = sonic_rs::from_str(&ac_bytes).unwrap();
+                let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
+                let ac: AhoCorasick = rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.stream_find_iter(buf)
                     .map(|result| result.unwrap())
                     .collect()
@@ -771,8 +771,8 @@ macro_rules! testconfig {
                     .prefilter(false)
                     .build(test.patterns)
                     .unwrap();
-                let ac_bytes = sonic_rs::to_string(&ac).unwrap();
-                let ac: AhoCorasick = sonic_rs::from_str(&ac_bytes).unwrap();
+                let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
+                let ac: AhoCorasick = rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.find_iter(test.haystack).collect()
             });
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -677,7 +677,8 @@ macro_rules! testconfig {
                     .build(test.patterns)
                     .unwrap();
                 let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
-                let ac: AhoCorasick = rmp_serde::from_slice(&ac_bytes).unwrap();
+                let ac: AhoCorasick =
+                    rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.try_find_iter(input).unwrap().collect()
             });
         }
@@ -705,7 +706,8 @@ macro_rules! testconfig {
                     .build(test.patterns)
                     .unwrap();
                 let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
-                let ac: AhoCorasick = rmp_serde::from_slice(&ac_bytes).unwrap();
+                let ac: AhoCorasick =
+                    rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.find_overlapping_iter(test.haystack).collect()
             });
         }
@@ -742,7 +744,8 @@ macro_rules! testconfig {
                     .build(test.patterns)
                     .unwrap();
                 let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
-                let ac: AhoCorasick = rmp_serde::from_slice(&ac_bytes).unwrap();
+                let ac: AhoCorasick =
+                    rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.stream_find_iter(buf)
                     .map(|result| result.unwrap())
                     .collect()
@@ -772,7 +775,8 @@ macro_rules! testconfig {
                     .build(test.patterns)
                     .unwrap();
                 let ac_bytes = rmp_serde::to_vec(&ac).unwrap();
-                let ac: AhoCorasick = rmp_serde::from_slice(&ac_bytes).unwrap();
+                let ac: AhoCorasick =
+                    rmp_serde::from_slice(&ac_bytes).unwrap();
                 ac.find_iter(test.haystack).collect()
             });
         }

--- a/src/util/primitives.rs
+++ b/src/util/primitives.rs
@@ -29,6 +29,8 @@ either a 32-bit integer or a `usize` (e.g., on 16-bit targets).
 #![allow(dead_code)]
 
 use alloc::vec::Vec;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::util::int::{Usize, U16, U32, U64};
 
@@ -92,6 +94,7 @@ use crate::util::int::{Usize, U16, U32, U64};
 #[derive(
     Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord,
 )]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 pub(crate) struct SmallIndex(u32);
 
@@ -709,6 +712,7 @@ macro_rules! index_type_impls {
 /// invalid value can be done in entirely safe code. This may in turn result in
 /// panics or silent logical errors.
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 pub struct PatternID(SmallIndex);
 
@@ -730,6 +734,7 @@ pub struct PatternID(SmallIndex);
 /// invalid value can be done in entirely safe code. This may in turn result in
 /// panics or silent logical errors.
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 pub struct StateID(SmallIndex);
 

--- a/src/util/search.rs
+++ b/src/util/search.rs
@@ -1,5 +1,8 @@
 use core::ops::{Range, RangeBounds};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::util::primitives::PatternID;
 
 /// The configuration and the haystack to use for an Aho-Corasick search.
@@ -1049,6 +1052,7 @@ impl Match {
 /// POSIX regex alternations.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MatchKind {
     /// Use standard match semantics, which support overlapping matches. When
     /// used with non-overlapping matches, matches are reported as they are
@@ -1130,6 +1134,7 @@ impl MatchKind {
 ///
 /// `AhoCorasick` by default only supports unanchored searches.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum StartKind {
     /// Support both anchored and unanchored searches.
     Both,

--- a/src/util/special.rs
+++ b/src/util/special.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::util::primitives::StateID;
 
 /// A collection of sentinel state IDs for Aho-Corasick automata.
@@ -7,6 +10,7 @@ use crate::util::primitives::StateID;
 /// particular order, we can determine the type of a state simply by looking at
 /// its ID.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub(crate) struct Special {
     /// The maximum ID of all the "special" states. This corresponds either to
     /// start_anchored_id when a prefilter is active and max_match_id when a


### PR DESCRIPTION
Simply implement serde, with prefilter disabled.

Motivation: I have thousands and millions of words have to run with aho-corasick, so I don't need prefilter due to the massive amount of patterns, but I do care build time.

Add serde test to tests.rs and have already done `cargo test --features "serde"`.

The serialization framework below is msgpack with `rmp_serde`.

* 100,000 words, build and deserialization benchmark.
<img width="708" alt="image" src="https://github.com/BurntSushi/aho-corasick/assets/51849534/3773f83d-ebf3-49a0-9461-86c6cf47dfd4">

* 1,000,000 words, build and deserialization benchmark.
<img width="671" alt="image" src="https://github.com/BurntSushi/aho-corasick/assets/51849534/dfe2b501-4535-4063-83d5-ddd07a7a238c">
