### PR TITLE
Optimize unanchored contiguous dense rows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ name = "aho_corasick"
 
 [features]
 default = ["std", "perf-literal"]
+alloc = []
 std = ["memchr?/std"]
 
 # Enables prefilter optimizations that depend on external crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ name = "aho_corasick"
 default = ["std", "perf-literal"]
 alloc = []
 std = ["memchr?/std"]
+perf-experiments = []
+perf-stats = []
 
 # Enables prefilter optimizations that depend on external crates.
 perf-literal = ["dep:memchr"]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -274,6 +274,52 @@ override this automatic selection via the `AhoCorasickBuilder::start_kind`
 configuration.)
 
 
+# Contiguous NFA dense rows
+
+The contiguous NFA uses a hybrid state encoding. Most states are sparse, some
+states with exactly one transition use a special one-transition encoding, and
+states near the start state are dense. A dense row has one transition slot for
+each byte equivalence class, which means search can find the next state with a
+single indexed load once the input byte has been mapped to its class.
+
+Dense rows are still part of an NFA, so a missing transition normally means
+"follow the failure transition and try the same byte again." In the encoded
+contiguous NFA, this is represented with a `FAIL` sentinel in the dense row.
+When search sees that sentinel, it jumps to the state's failure state and loops.
+This keeps construction cheap, but it means hot dense rows can still pay NFA
+failure-loop costs for common bytes that are not explicit transitions out of
+the current state.
+
+For top-level `AhoCorasick` values that only support unanchored searches, dense
+rows avoid that search-time cost by resolving missing dense transitions during
+construction. Instead of writing `FAIL` into each missing dense slot, the
+builder follows the failure links exactly as the search loop would and writes
+the resolved state ID directly. Explicit transitions are left unchanged. The
+result is not a full DFA, since sparse and one-transition rows still keep the
+usual NFA behavior, but dense rows behave more like DFA rows for unanchored
+searches. This removes many failure transitions from the hot search loop
+without increasing automaton heap usage for rows that were already dense.
+
+This optimization is deliberately not applied to automatons that must support
+anchored searches. In an anchored search, a missing transition cannot be
+resolved by falling back to the start state and continuing elsewhere in the
+haystack; that would turn an anchored prefix check into an unanchored search.
+Consequently, `StartKind::Anchored` and `StartKind::Both` keep the old dense
+row encoding with explicit `FAIL` sentinels. The low-level contiguous NFA
+builder also keeps its historical default; the failureless dense-row choice is
+made by the top-level `AhoCorasickBuilder` only when `StartKind::Unanchored`
+is in use.
+
+The trade-off is build time. Resolving a missing dense transition requires
+following failure links during construction for each missing byte class in each
+dense row. This does not add a second table and does not make already-dense
+rows larger, but it shifts some of the work that was previously paid during
+search into automaton construction. This is worthwhile for workloads where an
+automaton is searched many times or over large haystacks, especially when
+benchmarks show many dense-row `FAIL` hits. It is a less obvious win for
+short-lived automatons that are built once and searched only briefly.
+
+
 # More DFA tricks
 
 As described in the previous section, one of the downsides of using a DFA

--- a/aho-corasick-debug/Cargo.toml
+++ b/aho-corasick-debug/Cargo.toml
@@ -9,6 +9,10 @@ categories = ["text-processing"]
 autotests = false
 edition = "2018"
 
+[features]
+perf-experiments = ["aho-corasick/perf-experiments"]
+perf-stats = ["perf-experiments", "aho-corasick/perf-stats"]
+
 [[bin]]
 name = "aho-corasick-debug"
 path = "main.rs"

--- a/aho-corasick-debug/main.rs
+++ b/aho-corasick-debug/main.rs
@@ -18,12 +18,24 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    #[cfg(feature = "perf-stats")]
+    if args.perf_stats {
+        aho_corasick::nfa::contiguous::perf_stats::reset();
+    }
+
     let start = Instant::now();
     let count = ac.find_iter(&haystack).count();
     println!("match count: {}", count);
 
     let count_time = Instant::now().duration_since(start);
     eprintln!("count time: {:?}", count_time);
+    #[cfg(feature = "perf-stats")]
+    if args.perf_stats {
+        eprintln!(
+            "contiguous NFA perf stats:\n{}",
+            aho_corasick::nfa::contiguous::perf_stats::snapshot()
+        );
+    }
     Ok(())
 }
 
@@ -36,17 +48,23 @@ struct Args {
     kind: Option<AhoCorasickKind>,
     ascii_casei: bool,
     dense_depth: usize,
+    #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+    dense_transition_threshold: Option<usize>,
+    #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+    failureless_dense_rows: Option<bool>,
     no_prefilter: bool,
     no_classes: bool,
     no_search: bool,
     debug: bool,
+    #[cfg(feature = "perf-stats")]
+    perf_stats: bool,
 }
 
 impl Args {
     fn parse() -> anyhow::Result<Args> {
         use clap::{crate_authors, crate_version, App, Arg};
 
-        let parsed = App::new("Search using aho-corasick")
+        let app = App::new("Search using aho-corasick")
             .author(crate_authors!())
             .version(crate_version!())
             .max_term_width(100)
@@ -94,8 +112,27 @@ impl Args {
             )
             .arg(Arg::with_name("no-classes").long("no-classes").short("C"))
             .arg(Arg::with_name("no-search").long("no-search"))
-            .arg(Arg::with_name("debug").long("debug"))
-            .get_matches();
+            .arg(Arg::with_name("debug").long("debug"));
+        #[cfg(feature = "perf-stats")]
+        let app = app.arg(Arg::with_name("perf-stats").long("perf-stats"));
+        #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+        let app = app.arg(
+            Arg::with_name("dense-transition-threshold")
+                .long("dense-transition-threshold")
+                .takes_value(true),
+        );
+        #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+        let app = app.arg(
+            Arg::with_name("failureless-dense-rows")
+                .long("failureless-dense-rows"),
+        );
+        #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+        let app = app.arg(
+            Arg::with_name("no-failureless-dense-rows")
+                .long("no-failureless-dense-rows")
+                .conflicts_with("failureless-dense-rows"),
+        );
+        let parsed = app.get_matches();
 
         let dictionary =
             PathBuf::from(parsed.value_of_os("dictionary").unwrap());
@@ -120,7 +157,20 @@ impl Args {
             _ => unreachable!(),
         };
         let dense_depth = parsed.value_of("dense-depth").unwrap().parse()?;
-
+        #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+        let dense_transition_threshold = parsed
+            .value_of("dense-transition-threshold")
+            .map(str::parse)
+            .transpose()?;
+        #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+        let failureless_dense_rows =
+            if parsed.is_present("failureless-dense-rows") {
+                Some(true)
+            } else if parsed.is_present("no-failureless-dense-rows") {
+                Some(false)
+            } else {
+                None
+            };
         Ok(Args {
             dictionary,
             haystack,
@@ -128,11 +178,17 @@ impl Args {
             start_kind,
             kind,
             dense_depth,
+            #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+            dense_transition_threshold,
+            #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+            failureless_dense_rows,
             ascii_casei: parsed.is_present("ascii-case-insensitive"),
             no_prefilter: parsed.is_present("no-prefilter"),
             no_classes: parsed.is_present("no-classes"),
             no_search: parsed.is_present("no-search"),
             debug: parsed.is_present("debug"),
+            #[cfg(feature = "perf-stats")]
+            perf_stats: parsed.is_present("perf-stats"),
         })
     }
 
@@ -143,15 +199,22 @@ impl Args {
         eprintln!("pattern read time: {:?}", read_time);
 
         let start = Instant::now();
-        let ac = AhoCorasick::builder()
+        let mut builder = AhoCorasick::builder();
+        builder
             .match_kind(self.match_kind)
             .start_kind(self.start_kind)
             .kind(self.kind)
             .ascii_case_insensitive(self.ascii_casei)
             .dense_depth(self.dense_depth)
             .prefilter(!self.no_prefilter)
-            .byte_classes(!self.no_classes)
-            .build(patterns.lines())?;
+            .byte_classes(!self.no_classes);
+        #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+        builder.dense_transition_threshold(self.dense_transition_threshold);
+        #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+        if let Some(yes) = self.failureless_dense_rows {
+            builder.failureless_dense_rows(yes);
+        }
+        let ac = builder.build(patterns.lines())?;
         let build_time = Instant::now().duration_since(start);
         eprintln!("automaton build time: {:?}", build_time);
         Ok(ac)

--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -2144,6 +2144,8 @@ pub struct AhoCorasickBuilder {
     dfa: dfa::Builder,
     kind: Option<AhoCorasickKind>,
     start_kind: StartKind,
+    #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+    failureless_dense_rows: Option<bool>,
 }
 
 impl AhoCorasickBuilder {
@@ -2199,8 +2201,7 @@ impl AhoCorasickBuilder {
                 }
                 Some(AhoCorasickKind::ContiguousNFA) => {
                     debug!("forcefully chose contiguous NFA");
-                    let cnfa =
-                        self.nfa_contiguous.build_from_noncontiguous(&nfa)?;
+                    let cnfa = self.build_contiguous_nfa(&nfa)?;
                     (Arc::new(cnfa), AhoCorasickKind::ContiguousNFA)
                 }
                 Some(AhoCorasickKind::DFA) => {
@@ -2248,7 +2249,7 @@ impl AhoCorasickBuilder {
         // contiguous NFA is mostly just reshuffling data from a noncontiguous
         // NFA, so it isn't too expensive, especially relative to building a
         // noncontiguous NFA in the first place.
-        match self.nfa_contiguous.build_from_noncontiguous(&nfa) {
+        match self.build_contiguous_nfa(&nfa) {
             Ok(nfa) => {
                 debug!("chose contiguous NFA");
                 return (Arc::new(nfa), AhoCorasickKind::ContiguousNFA);
@@ -2264,6 +2265,21 @@ impl AhoCorasickBuilder {
         }
         debug!("chose non-contiguous NFA");
         (Arc::new(nfa), AhoCorasickKind::NoncontiguousNFA)
+    }
+
+    fn build_contiguous_nfa(
+        &self,
+        nfa: &noncontiguous::NFA,
+    ) -> Result<contiguous::NFA, BuildError> {
+        let mut builder = self.nfa_contiguous.clone();
+        let supports_failureless =
+            matches!(self.start_kind, StartKind::Unanchored);
+        let failureless = supports_failureless;
+        #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+        let failureless = self.failureless_dense_rows.unwrap_or(failureless)
+            && supports_failureless;
+        builder.failureless_dense_rows(failureless);
+        builder.build_from_noncontiguous(nfa)
     }
 
     /// Set the desired match semantics.
@@ -2587,6 +2603,28 @@ impl AhoCorasickBuilder {
     pub fn dense_depth(&mut self, depth: usize) -> &mut AhoCorasickBuilder {
         self.nfa_noncontiguous.dense_depth(depth);
         self.nfa_contiguous.dense_depth(depth);
+        self
+    }
+
+    /// Set a transition-count threshold for dense contiguous NFA rows.
+    #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+    #[doc(hidden)]
+    pub fn dense_transition_threshold(
+        &mut self,
+        threshold: Option<usize>,
+    ) -> &mut AhoCorasickBuilder {
+        self.nfa_contiguous.dense_transition_threshold(threshold);
+        self
+    }
+
+    /// Resolve missing dense contiguous NFA row transitions during build.
+    #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+    #[doc(hidden)]
+    pub fn failureless_dense_rows(
+        &mut self,
+        yes: bool,
+    ) -> &mut AhoCorasickBuilder {
+        self.failureless_dense_rows = Some(yes);
         self
     }
 

--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -399,7 +399,10 @@ impl AhoCorasick {
     /// // The correct leftmost-longest match here is 'abcd', but since we
     /// // told the search to quit as soon as it knows a match has occurred,
     /// // we get a different match back.
+    /// #[cfg(feature = "perf-literal")]
     /// assert_eq!("b", &haystack[mat.start()..mat.end()]);
+    /// #[cfg(not(feature = "perf-literal"))]
+    /// assert_eq!("abcd", &haystack[mat.start()..mat.end()]);
     /// ```
     pub fn find<'h, I: Into<Input<'h>>>(&self, input: I) -> Option<Match> {
         self.try_find(input)
@@ -948,7 +951,7 @@ impl AhoCorasick {
     /// let mat = ac.try_find(haystack)?.expect("should have a match");
     /// assert_eq!("abc", &haystack[mat.span()]);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// # Example: anchored leftmost-first searching
@@ -971,7 +974,7 @@ impl AhoCorasick {
     /// let input = Input::new(haystack).anchored(Anchored::Yes);
     /// assert_eq!(None, ac.try_find(input)?);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// If the beginning of the search is changed to where a match begins, then
@@ -992,7 +995,7 @@ impl AhoCorasick {
     /// let mat = ac.try_find(input)?.expect("should have a match");
     /// assert_eq!("abc", &haystack[mat.span()]);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// # Example: earliest leftmost-first searching
@@ -1014,9 +1017,12 @@ impl AhoCorasick {
     ///     .unwrap();
     /// let input = Input::new(haystack).earliest(true);
     /// let mat = ac.try_find(input)?.expect("should have a match");
+    /// #[cfg(feature = "perf-literal")]
     /// assert_eq!("b", &haystack[mat.span()]);
+    /// #[cfg(not(feature = "perf-literal"))]
+    /// assert_eq!("abc", &haystack[mat.span()]);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn try_find<'h, I: Into<Input<'h>>>(
         &self,
@@ -1087,7 +1093,7 @@ impl AhoCorasick {
     /// ac.try_find_overlapping(haystack, &mut state)?;
     /// assert_eq!(None, state.get_match());
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// # Example: implementing your own overlapping iteration
@@ -1135,7 +1141,7 @@ impl AhoCorasick {
     /// ];
     /// assert_eq!(expected, matches);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// # Example: anchored iteration
@@ -1179,7 +1185,7 @@ impl AhoCorasick {
     /// ];
     /// assert_eq!(expected, matches);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn try_find_overlapping<'h, I: Into<Input<'h>>>(
         &self,
@@ -1235,7 +1241,7 @@ impl AhoCorasick {
     ///     PatternID::must(0),
     /// ], matches);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// # Example: anchored leftmost-first searching
@@ -1270,7 +1276,7 @@ impl AhoCorasick {
     ///     // anchored.
     /// ], matches);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn try_find_iter<'a, 'h, I: Into<Input<'h>>>(
         &'a self,
@@ -1322,7 +1328,7 @@ impl AhoCorasick {
     ///     PatternID::must(1),
     /// ], matches);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// # Example: anchored overlapping search returns an error
@@ -1345,7 +1351,7 @@ impl AhoCorasick {
     /// let input = Input::new(haystack).anchored(Anchored::Yes);
     /// assert!(ac.try_find_overlapping_iter(input).is_err());
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn try_find_overlapping_iter<'a, 'h, I: Into<Input<'h>>>(
         &'a self,
@@ -1391,7 +1397,7 @@ impl AhoCorasick {
     /// let result = ac.try_replace_all(haystack, &["x", "y", "z"])?;
     /// assert_eq!("x the z to the xage", result);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn try_replace_all<B>(
         &self,
@@ -1442,7 +1448,7 @@ impl AhoCorasick {
     /// let result = ac.try_replace_all_bytes(haystack, &["x", "y", "z"])?;
     /// assert_eq!(b"x the z to the xage".to_vec(), result);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn try_replace_all_bytes<B>(
         &self,
@@ -1498,7 +1504,7 @@ impl AhoCorasick {
     /// })?;
     /// assert_eq!("0 the 2 to the 0age", result);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// Stopping the replacement by returning `false` (continued from the
@@ -1519,7 +1525,7 @@ impl AhoCorasick {
     /// })?;
     /// assert_eq!("0 the 2 to the appendage", result);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn try_replace_all_with<F>(
         &self,
@@ -1574,7 +1580,7 @@ impl AhoCorasick {
     /// })?;
     /// assert_eq!(b"0 the 2 to the 0age".to_vec(), result);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// Stopping the replacement by returning `false` (continued from the
@@ -1595,7 +1601,7 @@ impl AhoCorasick {
     /// })?;
     /// assert_eq!(b"0 the 2 to the appendage".to_vec(), result);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn try_replace_all_with_bytes<F>(
         &self,
@@ -2404,7 +2410,7 @@ impl AhoCorasickBuilder {
     /// let input = Input::new("abcd").anchored(Anchored::Yes);
     /// assert_eq!(Some(Match::must(1, 0..3)), ac.try_find(input)?);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     ///
     /// # Example: unanchored and anchored searches
@@ -2432,7 +2438,7 @@ impl AhoCorasickBuilder {
     /// let input = Input::new("abcd").anchored(Anchored::Yes);
     /// assert_eq!(Some(Match::must(1, 0..3)), ac.try_find(input)?);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     pub fn start_kind(&mut self, kind: StartKind) -> &mut AhoCorasickBuilder {
         self.dfa.start_kind(kind);

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -193,7 +193,7 @@ impl<'a, T: private::Sealed + ?Sized> private::Sealed for &'a T {}
 ///     .unwrap();
 /// assert_eq!(Some(Match::must(0, 0..7)), find(&nfa, b"samwise")?);
 ///
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), aho_corasick::MatchError>(())
 /// ```
 pub unsafe trait Automaton: private::Sealed {
     /// Returns the starting state for the given anchor mode.

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -82,7 +82,7 @@ use crate::{
 ///     Some(Match::must(0, 1..2)),
 ///     nfa.try_find(&Input::new(haystack))?,
 /// );
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), aho_corasick::MatchError>(())
 /// ```
 ///
 /// It is also possible to implement your own version of `try_find`. See the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,10 @@ this crate can be used without the standard library.
   Aho-Corasick for large numbers of patterns or otherwise can abide lower
   throughput when searching with a small number of patterns, then it is
   reasonable to disable this feature.
+* **alloc** -
+  A no-op compatibility feature for build configurations that explicitly
+  request allocation support. This crate always requires `alloc` when `std` is
+  disabled.
 * **logging** -
   Enables a dependency on the `log` crate and emits messages to aide in
   diagnostics. This feature is disabled by default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,12 @@ this crate can be used without the standard library.
   A no-op compatibility feature for build configurations that explicitly
   request allocation support. This crate always requires `alloc` when `std` is
   disabled.
+* **perf-experiments** -
+  Enables internal benchmarking knobs for performance experiments. This is
+  disabled by default.
+* **perf-stats** -
+  Enables internal counters for contiguous NFA transition profiling. This is
+  intended for benchmarking and is disabled by default.
 * **logging** -
   Enables a dependency on the `log` crate and emits messages to aide in
   diagnostics. This feature is disabled by default.

--- a/src/nfa/contiguous.rs
+++ b/src/nfa/contiguous.rs
@@ -82,7 +82,7 @@ use crate::{
 ///     Some(Match::must(0, 1..2)),
 ///     nfa.try_find(&Input::new(haystack))?,
 /// );
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), aho_corasick::MatchError>(())
 /// ```
 ///
 /// It is also possible to implement your own version of `try_find`. See the

--- a/src/nfa/contiguous.rs
+++ b/src/nfa/contiguous.rs
@@ -23,6 +23,165 @@ use crate::{
     },
 };
 
+/// Internal transition counters for contiguous NFA profiling.
+#[cfg(feature = "perf-stats")]
+#[doc(hidden)]
+pub mod perf_stats {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A point-in-time snapshot of contiguous NFA transition counters.
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    pub struct Stats {
+        /// Calls to `Automaton::next_state`.
+        pub input_transition_calls: usize,
+        /// State rows visited by the inner failure loop.
+        pub loop_state_visits: usize,
+        /// Failure links followed.
+        pub failure_transitions: usize,
+        /// Dense rows visited.
+        pub dense_row_visits: usize,
+        /// Dense rows whose selected transition was `FAIL`.
+        pub dense_row_fail_hits: usize,
+        /// One-transition rows visited.
+        pub one_transition_row_visits: usize,
+        /// Sparse rows visited.
+        pub sparse_row_visits: usize,
+        /// Sparse class chunks scanned.
+        pub sparse_chunks_scanned: usize,
+        /// Sparse rows that contained the requested transition.
+        pub sparse_hits: usize,
+        /// Sparse rows that did not contain the requested transition.
+        pub sparse_misses: usize,
+    }
+
+    static INPUT_TRANSITION_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static LOOP_STATE_VISITS: AtomicUsize = AtomicUsize::new(0);
+    static FAILURE_TRANSITIONS: AtomicUsize = AtomicUsize::new(0);
+    static DENSE_ROW_VISITS: AtomicUsize = AtomicUsize::new(0);
+    static DENSE_ROW_FAIL_HITS: AtomicUsize = AtomicUsize::new(0);
+    static ONE_TRANSITION_ROW_VISITS: AtomicUsize = AtomicUsize::new(0);
+    static SPARSE_ROW_VISITS: AtomicUsize = AtomicUsize::new(0);
+    static SPARSE_CHUNKS_SCANNED: AtomicUsize = AtomicUsize::new(0);
+    static SPARSE_HITS: AtomicUsize = AtomicUsize::new(0);
+    static SPARSE_MISSES: AtomicUsize = AtomicUsize::new(0);
+
+    macro_rules! counter {
+        ($name:ident) => {
+            $name.fetch_add(1, Ordering::Relaxed);
+        };
+    }
+
+    /// Reset all contiguous NFA transition counters to zero.
+    pub fn reset() {
+        INPUT_TRANSITION_CALLS.store(0, Ordering::Relaxed);
+        LOOP_STATE_VISITS.store(0, Ordering::Relaxed);
+        FAILURE_TRANSITIONS.store(0, Ordering::Relaxed);
+        DENSE_ROW_VISITS.store(0, Ordering::Relaxed);
+        DENSE_ROW_FAIL_HITS.store(0, Ordering::Relaxed);
+        ONE_TRANSITION_ROW_VISITS.store(0, Ordering::Relaxed);
+        SPARSE_ROW_VISITS.store(0, Ordering::Relaxed);
+        SPARSE_CHUNKS_SCANNED.store(0, Ordering::Relaxed);
+        SPARSE_HITS.store(0, Ordering::Relaxed);
+        SPARSE_MISSES.store(0, Ordering::Relaxed);
+    }
+
+    /// Return a point-in-time snapshot of all contiguous NFA counters.
+    pub fn snapshot() -> Stats {
+        Stats {
+            input_transition_calls: INPUT_TRANSITION_CALLS
+                .load(Ordering::Relaxed),
+            loop_state_visits: LOOP_STATE_VISITS.load(Ordering::Relaxed),
+            failure_transitions: FAILURE_TRANSITIONS.load(Ordering::Relaxed),
+            dense_row_visits: DENSE_ROW_VISITS.load(Ordering::Relaxed),
+            dense_row_fail_hits: DENSE_ROW_FAIL_HITS.load(Ordering::Relaxed),
+            one_transition_row_visits: ONE_TRANSITION_ROW_VISITS
+                .load(Ordering::Relaxed),
+            sparse_row_visits: SPARSE_ROW_VISITS.load(Ordering::Relaxed),
+            sparse_chunks_scanned: SPARSE_CHUNKS_SCANNED
+                .load(Ordering::Relaxed),
+            sparse_hits: SPARSE_HITS.load(Ordering::Relaxed),
+            sparse_misses: SPARSE_MISSES.load(Ordering::Relaxed),
+        }
+    }
+
+    impl core::fmt::Display for Stats {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            writeln!(
+                f,
+                "input transition calls: {}",
+                self.input_transition_calls
+            )?;
+            writeln!(f, "loop state visits: {}", self.loop_state_visits)?;
+            writeln!(f, "failure transitions: {}", self.failure_transitions)?;
+            writeln!(f, "dense row visits: {}", self.dense_row_visits)?;
+            writeln!(f, "dense row FAIL hits: {}", self.dense_row_fail_hits)?;
+            writeln!(
+                f,
+                "one-transition row visits: {}",
+                self.one_transition_row_visits
+            )?;
+            writeln!(f, "sparse row visits: {}", self.sparse_row_visits)?;
+            writeln!(
+                f,
+                "sparse chunks scanned: {}",
+                self.sparse_chunks_scanned
+            )?;
+            writeln!(f, "sparse hits: {}", self.sparse_hits)?;
+            write!(f, "sparse misses: {}", self.sparse_misses)
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn input_transition_call() {
+        counter!(INPUT_TRANSITION_CALLS);
+    }
+
+    #[inline(always)]
+    pub(crate) fn loop_state_visit() {
+        counter!(LOOP_STATE_VISITS);
+    }
+
+    #[inline(always)]
+    pub(crate) fn failure_transition() {
+        counter!(FAILURE_TRANSITIONS);
+    }
+
+    #[inline(always)]
+    pub(crate) fn dense_row_visit() {
+        counter!(DENSE_ROW_VISITS);
+    }
+
+    #[inline(always)]
+    pub(crate) fn dense_row_fail_hit() {
+        counter!(DENSE_ROW_FAIL_HITS);
+    }
+
+    #[inline(always)]
+    pub(crate) fn one_transition_row_visit() {
+        counter!(ONE_TRANSITION_ROW_VISITS);
+    }
+
+    #[inline(always)]
+    pub(crate) fn sparse_row_visit() {
+        counter!(SPARSE_ROW_VISITS);
+    }
+
+    #[inline(always)]
+    pub(crate) fn sparse_chunk_scanned() {
+        counter!(SPARSE_CHUNKS_SCANNED);
+    }
+
+    #[inline(always)]
+    pub(crate) fn sparse_hit() {
+        counter!(SPARSE_HITS);
+    }
+
+    #[inline(always)]
+    pub(crate) fn sparse_miss() {
+        counter!(SPARSE_MISSES);
+    }
+}
+
 /// A contiguous NFA implementation of Aho-Corasick.
 ///
 /// When possible, prefer using [`AhoCorasick`](crate::AhoCorasick) instead of
@@ -192,7 +351,11 @@ unsafe impl Automaton for NFA {
         let repr = &self.repr;
         let class = self.byte_classes.get(byte);
         let u32tosid = StateID::from_u32_unchecked;
+        #[cfg(feature = "perf-stats")]
+        perf_stats::input_transition_call();
         loop {
+            #[cfg(feature = "perf-stats")]
+            perf_stats::loop_state_visit();
             let o = sid.as_usize();
             let kind = repr[o] & 0xFF;
             // I tried to encapsulate the "next transition" logic into its own
@@ -203,15 +366,23 @@ unsafe impl Automaton for NFA {
             // I've also tried a lot of different ways to speed up this
             // routine, and most of them have failed.
             if kind == State::KIND_DENSE {
+                #[cfg(feature = "perf-stats")]
+                perf_stats::dense_row_visit();
                 let next = u32tosid(repr[o + 2 + usize::from(class)]);
                 if next != NFA::FAIL {
                     return next;
                 }
+                #[cfg(feature = "perf-stats")]
+                perf_stats::dense_row_fail_hit();
             } else if kind == State::KIND_ONE {
+                #[cfg(feature = "perf-stats")]
+                perf_stats::one_transition_row_visit();
                 if class == repr[o].low_u16().high_u8() {
                     return u32tosid(repr[o + 2]);
                 }
             } else {
+                #[cfg(feature = "perf-stats")]
+                perf_stats::sparse_row_visit();
                 // NOTE: I tried a SWAR technique in the loop below, but found
                 // it slower. See the 'swar' test in the tests for this module.
                 let trans_len = kind.as_usize();
@@ -220,20 +391,32 @@ unsafe impl Automaton for NFA {
                 for (i, &chunk) in
                     repr[o + 2..][..classes_len].iter().enumerate()
                 {
+                    #[cfg(feature = "perf-stats")]
+                    perf_stats::sparse_chunk_scanned();
                     let classes = chunk.to_ne_bytes();
                     if classes[0] == class {
+                        #[cfg(feature = "perf-stats")]
+                        perf_stats::sparse_hit();
                         return u32tosid(repr[trans_offset + i * 4]);
                     }
                     if classes[1] == class {
+                        #[cfg(feature = "perf-stats")]
+                        perf_stats::sparse_hit();
                         return u32tosid(repr[trans_offset + i * 4 + 1]);
                     }
                     if classes[2] == class {
+                        #[cfg(feature = "perf-stats")]
+                        perf_stats::sparse_hit();
                         return u32tosid(repr[trans_offset + i * 4 + 2]);
                     }
                     if classes[3] == class {
+                        #[cfg(feature = "perf-stats")]
+                        perf_stats::sparse_hit();
                         return u32tosid(repr[trans_offset + i * 4 + 3]);
                     }
                 }
+                #[cfg(feature = "perf-stats")]
+                perf_stats::sparse_miss();
             }
             // For an anchored search, we never follow failure transitions
             // because failure transitions lead us down a path to matching
@@ -242,6 +425,8 @@ unsafe impl Automaton for NFA {
             if anchored.is_anchored() {
                 return NFA::DEAD;
             }
+            #[cfg(feature = "perf-stats")]
+            perf_stats::failure_transition();
             sid = u32tosid(repr[o + 1]);
         }
     }
@@ -690,6 +875,8 @@ impl<'a> State<'a> {
         classes: &ByteClasses,
         dst: &mut Vec<u32>,
         force_dense: bool,
+        dense_transition_threshold: Option<usize>,
+        failureless_dense_rows: bool,
     ) -> Result<StateID, BuildError> {
         let sid = StateID::new(dst.len()).map_err(|e| {
             BuildError::state_id_overflow(StateID::MAX.as_u64(), e.attempted())
@@ -700,7 +887,12 @@ impl<'a> State<'a> {
         // okay with it. This also gives us more sentinels in the state's
         // 'kind', which lets us create different state kinds to save on
         // space.
-        let kind = if force_dense || old_len > State::MAX_SPARSE_TRANSITIONS {
+        let should_dense_by_count =
+            dense_transition_threshold.map_or(false, |min| old_len >= min);
+        let kind = if force_dense
+            || should_dense_by_count
+            || old_len > State::MAX_SPARSE_TRANSITIONS
+        {
             State::KIND_DENSE
         } else if old_len == 1 && !old.is_match() {
             State::KIND_ONE
@@ -711,7 +903,13 @@ impl<'a> State<'a> {
         if kind == State::KIND_DENSE {
             dst.push(kind);
             dst.push(old.fail().as_u32());
-            State::write_dense_trans(nnfa, oldsid, classes, dst)?;
+            State::write_dense_trans(
+                nnfa,
+                oldsid,
+                classes,
+                dst,
+                failureless_dense_rows,
+            )?;
         } else if kind == State::KIND_ONE {
             let t = nnfa.iter_trans(oldsid).next().unwrap();
             let class = u32::from(classes.get(t.byte()));
@@ -795,6 +993,7 @@ impl<'a> State<'a> {
         oldsid: StateID,
         classes: &ByteClasses,
         dst: &mut Vec<u32>,
+        failureless: bool,
     ) -> Result<(), BuildError> {
         // Our byte classes let us shrink the size of our dense states to the
         // number of equivalence classes instead of just fixing it to 256.
@@ -807,16 +1006,44 @@ impl<'a> State<'a> {
         // IDs from the noncontiguous NFA. It isn't until we've added all
         // states that we go back and map noncontiguous IDs to contiguous IDs.
         let start = dst.len();
-        dst.extend(
-            core::iter::repeat(noncontiguous::NFA::FAIL.as_u32())
-                .take(classes.alphabet_len()),
-        );
+        if failureless {
+            let fail = nnfa.states()[oldsid].fail();
+            for class in classes.iter() {
+                let byte = classes.elements(class).next().unwrap();
+                dst.push(
+                    State::next_state_unanchored(nnfa, fail, byte).as_u32(),
+                );
+            }
+        } else {
+            dst.extend(
+                core::iter::repeat(noncontiguous::NFA::FAIL.as_u32())
+                    .take(classes.alphabet_len()),
+            );
+        }
         assert!(start < dst.len(), "equivalence classes are never empty");
         for t in nnfa.iter_trans(oldsid) {
             dst[start + usize::from(classes.get(t.byte()))] =
                 t.next().as_u32();
         }
         Ok(())
+    }
+
+    fn next_state_unanchored(
+        nnfa: &noncontiguous::NFA,
+        mut sid: StateID,
+        byte: u8,
+    ) -> StateID {
+        loop {
+            for t in nnfa.iter_trans(sid) {
+                if byte <= t.byte() {
+                    if byte == t.byte() {
+                        return t.next();
+                    }
+                    break;
+                }
+            }
+            sid = nnfa.states()[sid].fail();
+        }
     }
 
     /// Return an iterator over every explicitly defined transition in this
@@ -894,6 +1121,8 @@ impl<'a> core::fmt::Debug for State<'a> {
 pub struct Builder {
     noncontiguous: noncontiguous::Builder,
     dense_depth: usize,
+    dense_transition_threshold: Option<usize>,
+    failureless_dense_rows: bool,
     byte_classes: bool,
 }
 
@@ -902,6 +1131,8 @@ impl Default for Builder {
         Builder {
             noncontiguous: noncontiguous::Builder::new(),
             dense_depth: 2,
+            dense_transition_threshold: None,
+            failureless_dense_rows: false,
             byte_classes: true,
         }
     }
@@ -974,6 +1205,8 @@ impl Builder {
                 &nfa.byte_classes,
                 &mut nfa.repr,
                 force_dense,
+                self.dense_transition_threshold,
+                self.failureless_dense_rows,
             )?;
             index_to_state_id[oldsid] = newsid;
         }
@@ -1055,6 +1288,25 @@ impl Builder {
     /// for more documentation and examples.
     pub fn dense_depth(&mut self, depth: usize) -> &mut Builder {
         self.dense_depth = depth;
+        self
+    }
+
+    /// Set a transition-count threshold for forcing states to use dense rows.
+    #[cfg(any(feature = "perf-stats", feature = "perf-experiments"))]
+    #[doc(hidden)]
+    pub fn dense_transition_threshold(
+        &mut self,
+        threshold: Option<usize>,
+    ) -> &mut Builder {
+        self.dense_transition_threshold = threshold;
+        self
+    }
+
+    pub(crate) fn failureless_dense_rows(
+        &mut self,
+        yes: bool,
+    ) -> &mut Builder {
+        self.failureless_dense_rows = yes;
         self
     }
 

--- a/src/nfa/noncontiguous.rs
+++ b/src/nfa/noncontiguous.rs
@@ -73,7 +73,7 @@ use crate::{
 ///     Some(Match::must(0, 1..2)),
 ///     nfa.try_find(&Input::new(haystack))?,
 /// );
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), aho_corasick::MatchError>(())
 /// ```
 ///
 /// It is also possible to implement your own version of `try_find`. See the

--- a/src/packed/api.rs
+++ b/src/packed/api.rs
@@ -75,9 +75,9 @@ impl Default for MatchKind {
 ///     .collect();
 /// assert_eq!(vec![PatternID::must(1)], matches);
 /// # Some(()) }
-/// # if cfg!(all(feature = "std", any(
+/// # if cfg!(any(
 /// #     target_arch = "x86_64", target_arch = "aarch64",
-/// # ))) {
+/// # )) {
 /// #     example().unwrap()
 /// # } else {
 /// #     assert!(example().is_none());
@@ -220,9 +220,9 @@ impl Config {
 ///     .collect();
 /// assert_eq!(vec![PatternID::ZERO], matches);
 /// # Some(()) }
-/// # if cfg!(all(feature = "std", any(
+/// # if cfg!(any(
 /// #     target_arch = "x86_64", target_arch = "aarch64",
-/// # ))) {
+/// # )) {
 /// #     example().unwrap()
 /// # } else {
 /// #     assert!(example().is_none());
@@ -384,9 +384,9 @@ impl Default for Builder {
 ///     .collect();
 /// assert_eq!(vec![PatternID::ZERO], matches);
 /// # Some(()) }
-/// # if cfg!(all(feature = "std", any(
+/// # if cfg!(any(
 /// #     target_arch = "x86_64", target_arch = "aarch64",
-/// # ))) {
+/// # )) {
 /// #     example().unwrap()
 /// # } else {
 /// #     assert!(example().is_none());
@@ -429,9 +429,9 @@ impl Searcher {
     ///     .collect();
     /// assert_eq!(vec![PatternID::ZERO], matches);
     /// # Some(()) }
-    /// # if cfg!(all(feature = "std", any(
+    /// # if cfg!(any(
     /// #     target_arch = "x86_64", target_arch = "aarch64",
-    /// # ))) {
+    /// # )) {
     /// #     example().unwrap()
     /// # } else {
     /// #     assert!(example().is_none());
@@ -479,9 +479,9 @@ impl Searcher {
     /// assert_eq!(0, mat.start());
     /// assert_eq!(6, mat.end());
     /// # Some(()) }
-    /// # if cfg!(all(feature = "std", any(
+    /// # if cfg!(any(
     /// #     target_arch = "x86_64", target_arch = "aarch64",
-    /// # ))) {
+    /// # )) {
     /// #     example().unwrap()
     /// # } else {
     /// #     assert!(example().is_none());
@@ -521,9 +521,9 @@ impl Searcher {
     /// assert_eq!(3, mat.start());
     /// assert_eq!(9, mat.end());
     /// # Some(()) }
-    /// # if cfg!(all(feature = "std", any(
+    /// # if cfg!(any(
     /// #     target_arch = "x86_64", target_arch = "aarch64",
-    /// # ))) {
+    /// # )) {
     /// #     example().unwrap()
     /// # } else {
     /// #     assert!(example().is_none());
@@ -572,9 +572,9 @@ impl Searcher {
     ///     PatternID::must(1),
     /// ], matches);
     /// # Some(()) }
-    /// # if cfg!(all(feature = "std", any(
+    /// # if cfg!(any(
     /// #     target_arch = "x86_64", target_arch = "aarch64",
-    /// # ))) {
+    /// # )) {
     /// #     example().unwrap()
     /// # } else {
     /// #     assert!(example().is_none());
@@ -604,9 +604,9 @@ impl Searcher {
     /// // leftmost-first is the default.
     /// assert_eq!(&MatchKind::LeftmostFirst, searcher.match_kind());
     /// # Some(()) }
-    /// # if cfg!(all(feature = "std", any(
+    /// # if cfg!(any(
     /// #     target_arch = "x86_64", target_arch = "aarch64",
-    /// # ))) {
+    /// # )) {
     /// #     example().unwrap()
     /// # } else {
     /// #     assert!(example().is_none());

--- a/src/packed/mod.rs
+++ b/src/packed/mod.rs
@@ -40,9 +40,9 @@ let matches: Vec<PatternID> = searcher
     .collect();
 assert_eq!(vec![PatternID::ZERO], matches);
 # Some(()) }
-# if cfg!(all(feature = "std", any(
+# if cfg!(any(
 #     target_arch = "x86_64", target_arch = "aarch64",
-# ))) {
+# )) {
 #     example().unwrap()
 # } else {
 #     assert!(example().is_none());
@@ -68,9 +68,9 @@ let matches: Vec<PatternID> = searcher
     .collect();
 assert_eq!(vec![PatternID::must(1)], matches);
 # Some(()) }
-# if cfg!(all(feature = "std", any(
+# if cfg!(any(
 #     target_arch = "x86_64", target_arch = "aarch64",
-# ))) {
+# )) {
 #     example().unwrap()
 # } else {
 #     assert!(example().is_none());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1510,6 +1510,81 @@ fn unanchored_not_allowed_even_if_technically_available() {
     assert!(ac.try_find(Input::new("foo").anchored(Anchored::No)).is_err());
 }
 
+#[cfg(feature = "perf-experiments")]
+#[test]
+fn failureless_dense_rows_preserve_anchored_semantics() {
+    for &start_kind in &[StartKind::Anchored, StartKind::Both] {
+        let mut control = AhoCorasick::builder();
+        control
+            .kind(Some(AhoCorasickKind::ContiguousNFA))
+            .start_kind(start_kind);
+        let control = control.build(&["b"]).unwrap();
+
+        let mut candidate = AhoCorasick::builder();
+        candidate
+            .kind(Some(AhoCorasickKind::ContiguousNFA))
+            .start_kind(start_kind)
+            .failureless_dense_rows(true);
+        let candidate = candidate.build(&["b"]).unwrap();
+
+        let input = || Input::new("ab").anchored(Anchored::Yes);
+        assert_eq!(
+            control.try_find(input()).unwrap(),
+            candidate.try_find(input()).unwrap(),
+            "start kind: {:?}",
+            start_kind,
+        );
+        assert_eq!(None, candidate.try_find(input()).unwrap());
+
+        if start_kind == StartKind::Both {
+            let input = || Input::new("ab").anchored(Anchored::No);
+            assert_eq!(
+                control.try_find(input()).unwrap(),
+                candidate.try_find(input()).unwrap(),
+            );
+            assert_eq!(
+                Some(Match::must(0, 1..2)),
+                candidate.try_find(input()).unwrap(),
+            );
+        }
+    }
+}
+
+#[cfg(feature = "perf-experiments")]
+#[test]
+fn failureless_dense_rows_preserve_unanchored_results() {
+    for &byte_classes in &[true, false] {
+        let mut control = AhoCorasick::builder();
+        control
+            .kind(Some(AhoCorasickKind::ContiguousNFA))
+            .start_kind(StartKind::Unanchored)
+            .byte_classes(byte_classes)
+            .prefilter(false)
+            .failureless_dense_rows(false);
+        let control = control.build(&["bc", "abcd", "bcd", "z"]).unwrap();
+
+        let mut candidate = AhoCorasick::builder();
+        candidate
+            .kind(Some(AhoCorasickKind::ContiguousNFA))
+            .start_kind(StartKind::Unanchored)
+            .byte_classes(byte_classes)
+            .prefilter(false)
+            .failureless_dense_rows(true);
+        let candidate = candidate.build(&["bc", "abcd", "bcd", "z"]).unwrap();
+
+        let haystack = "xxabcdzbc";
+        let control_matches: Vec<Match> =
+            control.find_iter(haystack).collect();
+        let candidate_matches: Vec<Match> =
+            candidate.find_iter(haystack).collect();
+        assert_eq!(
+            control_matches, candidate_matches,
+            "byte classes: {}",
+            byte_classes,
+        );
+    }
+}
+
 // This tests that a prefilter does not cause a search to report a match
 // outside the bounds provided by the caller.
 //

--- a/src/util/search.rs
+++ b/src/util/search.rs
@@ -136,7 +136,7 @@ impl<'h> Input<'h> {
     /// // because it is the correct leftmost-first match.
     /// assert_eq!("abc", &haystack[mat.span()]);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     #[inline]
     pub fn span<S: Into<Span>>(mut self, span: S) -> Input<'h> {
@@ -246,7 +246,7 @@ impl<'h> Input<'h> {
     /// let mat = ac.try_find(input)?.expect("should have a match");
     /// assert_eq!("bcd", &haystack[mat.span()]);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     #[inline]
     pub fn anchored(mut self, mode: Anchored) -> Input<'h> {
@@ -294,9 +294,12 @@ impl<'h> Input<'h> {
     /// // The "earliest" possible match, even if it isn't leftmost-first.
     /// let input = Input::new(haystack).earliest(true);
     /// let mat = ac.try_find(input)?.expect("should have a match");
+    /// #[cfg(feature = "perf-literal")]
     /// assert_eq!("b", &haystack[mat.span()]);
+    /// #[cfg(not(feature = "perf-literal"))]
+    /// assert_eq!("abc", &haystack[mat.span()]);
     ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), aho_corasick::MatchError>(())
     /// ```
     #[inline]
     pub fn earliest(mut self, yes: bool) -> Input<'h> {


### PR DESCRIPTION
## Problem

The contiguous NFA keeps dense rows for states near the start state, but missing
transitions in those rows were still encoded as `FAIL`. In unanchored searches,
that meant the hot loop frequently loaded a dense row, hit `FAIL`, followed the
failure link, and retried the same byte.

Measured profiling showed this shape clearly: many failure transitions and many
dense-row `FAIL` hits on large-pattern workloads.

## Approach

This changes top-level unanchored contiguous NFAs to resolve missing dense-row
transitions during construction. For each missing dense byte-class slot, the
builder follows failure links exactly as the unanchored search loop would and
writes the resolved state ID directly.

Explicit dense transitions are unchanged. Sparse rows and one-transition rows
keep the existing NFA behavior. This does not add a second table and does not
increase heap usage for rows that were already dense.

Anchored correctness is the main boundary:

- `StartKind::Unanchored` uses failureless dense rows.
- `StartKind::Anchored` keeps dense `FAIL` sentinels.
- `StartKind::Both` keeps dense `FAIL` sentinels.
- The low-level contiguous NFA builder keeps its historical default.

The PR also adds gated benchmark-only instrumentation and internal experiment
knobs used to measure this change. They are disabled by default.

## Trade-off

The optimization shifts some work from search time to build time. Resolving a
missing dense transition now follows failure links during construction for each
missing byte class in each dense row.

This is a good trade-off for automatons searched repeatedly or over large
haystacks, where search-time savings dominate. It is less compelling for
short-lived automatons that are built once and searched briefly.

## Correctness

Commands run:

```sh
cargo test --all-features
cargo test --no-default-features --features alloc
```

Both passed.

The all-features run includes the `perf-experiments` regression tests for
failureless dense rows, including anchored behavior and byte-classes on/off.

## Benchmarks

Each direct timing command was run repeatedly with release builds and
`--dense-depth 2`. The table reports medians.

| case | build before | build after | heap before | heap after | count before | count after | search change | matches |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| words5000_random | 2.884ms | 9.698ms | 531708 | 531708 | 320.416us | 215.625us | -32.7% | 0 |
| words15000_en | 9.091ms | 17.759ms | 1188044 | 1188044 | 5.652ms | 4.553ms | -19.4% | 2126 |
| english15_en | 1.659ms | 4.441ms | 345772 | 345772 | 4.710ms | 2.479ms | -47.4% | 15 |

Instrumentation counters show the intended mechanism:

| case | failure transitions before | failure transitions after | dense FAIL hits before | dense FAIL hits after |
| --- | ---: | ---: | ---: | ---: |
| words5000_random | 89610 | 4650 | 84960 | 0 |
| words15000_en | 551704 | 174108 | 377596 | 0 |
| english15_en | 576750 | 91565 | 485185 | 0 |

Build time increases because missing dense transitions are resolved eagerly.
Automaton heap usage and match counts were unchanged in these focused runs.

## Notes

I also tested a count-based dense-row threshold sweep and a dense failureless
cache experiment while measuring this change. The accepted default here is only
failureless dense rows for top-level unanchored contiguous NFAs; the cache
experiment was rejected due to memory pressure and was not kept.
