### PR TITLE
Various DFA performance improvements

### DIFF
--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -1982,14 +1982,14 @@ impl AhoCorasick {
     ///     .kind(None) // default
     ///     .build(&["foobar", "bruce", "triskaidekaphobia", "springsteen"])
     ///     .unwrap();
-    /// assert_eq!(5_632, ac.memory_usage());
+    /// assert_eq!(5_556, ac.memory_usage());
     ///
     /// let ac = AhoCorasick::builder()
     ///     .kind(None) // default
     ///     .ascii_case_insensitive(true)
     ///     .build(&["foobar", "bruce", "triskaidekaphobia", "springsteen"])
     ///     .unwrap();
-    /// assert_eq!(11_136, ac.memory_usage());
+    /// assert_eq!(11_060, ac.memory_usage());
     ///
     /// let ac = AhoCorasick::builder()
     ///     .kind(Some(AhoCorasickKind::NoncontiguousNFA))
@@ -2016,7 +2016,7 @@ impl AhoCorasick {
     /// // will reveal that the rate of growth of the DFA is far bigger than
     /// // the NFAs above. For a large number of patterns, it is easy for the
     /// // DFA to take an order of magnitude more heap space (or more!).
-    /// assert_eq!(11_136, ac.memory_usage());
+    /// assert_eq!(11_060, ac.memory_usage());
     /// ```
     pub fn memory_usage(&self) -> usize {
         self.aut.memory_usage()

--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -2665,6 +2665,11 @@ unsafe impl Automaton for Arc<dyn AcAutomaton> {
     }
 
     #[inline(always)]
+    fn prefers_interleaved_scan(&self) -> bool {
+        (**self).prefers_interleaved_scan()
+    }
+
+    #[inline(always)]
     fn next_state(
         &self,
         anchored: Anchored,

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -345,6 +345,20 @@ pub unsafe trait Automaton: private::Sealed {
     /// number of patterns built into the automaton.
     fn prefilter(&self) -> Option<&Prefilter>;
 
+    /// Returns true when this automaton benefits from scanning blocks of a
+    /// haystack with several interleaved independent walks, as done by
+    /// `FindOverlappingIter`.
+    ///
+    /// This is an internal heuristic hook and not part of the public API.
+    /// Only the DFA returns true: its transitions are cheap and constant
+    /// time, so interleaving hides the latency of its (often cache-resident
+    /// at best) transition table lookups. The NFAs' costlier transition
+    /// functions make interleaving a pessimization instead.
+    #[doc(hidden)]
+    fn prefers_interleaved_scan(&self) -> bool {
+        false
+    }
+
     /// Executes a non-overlapping search with this automaton using the given
     /// configuration.
     ///
@@ -401,25 +415,7 @@ pub unsafe trait Automaton: private::Sealed {
     where
         Self: Sized,
     {
-        if !self.match_kind().is_standard() {
-            return Err(MatchError::unsupported_overlapping(
-                self.match_kind(),
-            ));
-        }
-        //  We might consider lifting this restriction. The reason why I added
-        // it was to ban the combination of "anchored search" and "overlapping
-        // iteration." The match semantics aren't totally clear in that case.
-        // Should we allow *any* matches that are adjacent to *any* previous
-        // match? Or only following the most recent one? Or only matches
-        // that start at the beginning of the search? We might also elect to
-        // just keep this restriction in place, as callers should be able to
-        // implement it themselves if they want to.
-        if input.get_anchored().is_anchored() {
-            return Err(MatchError::invalid_input_anchored());
-        }
-        let _ = self.start_state(input.get_anchored())?;
-        let state = OverlappingState::start();
-        Ok(FindOverlappingIter { aut: self, input, state })
+        FindOverlappingIter::new(self, input)
     }
 
     /// Replaces all non-overlapping matches in `haystack` with
@@ -642,6 +638,11 @@ unsafe impl<'a, A: Automaton + ?Sized> Automaton for &'a A {
     #[inline(always)]
     fn start_state(&self, anchored: Anchored) -> Result<StateID, MatchError> {
         (**self).start_state(anchored)
+    }
+
+    #[inline(always)]
+    fn prefers_interleaved_scan(&self) -> bool {
+        (**self).prefers_interleaved_scan()
     }
 
     #[inline(always)]
@@ -954,7 +955,316 @@ impl<'a, 'h, A: Automaton> Iterator for FindIter<'a, 'h, A> {
 pub struct FindOverlappingIter<'a, 'h, A> {
     aut: &'a A,
     input: Input<'h>,
+    /// The resumable search state. This is used only for automatons that do
+    /// not prefer interleaved block scanning (see
+    /// `Automaton::prefers_interleaved_scan`, i.e., everything but the DFA):
+    /// those run the byte-at-a-time resumable search, yielding each match
+    /// directly with no buffering at all. For the DFA, all fields below drive
+    /// the buffered block scanner instead.
     state: OverlappingState,
+    /// The start state for unanchored searches, used to initialize the
+    /// warm-up of each stream in a block scan.
+    start: StateID,
+    /// The position of the first byte not yet consumed by the search, in
+    /// absolute haystack offsets.
+    at: usize,
+    /// The automaton state corresponding to the position `at`. A `None`
+    /// indicates that the search is over: the end of the span was reached, a
+    /// dead state was entered or a prefilter reported that no candidates
+    /// remain.
+    sid: Option<StateID>,
+    /// The matches found by the most recent block scan that have not been
+    /// yielded yet. `buf[buf_next..]` is yielded in order before the next
+    /// block is scanned.
+    buf: Vec<Match>,
+    buf_next: usize,
+    /// Scratch buffers holding the matches found by the streams (other than
+    /// the first one, which writes to `buf` directly) of a block scan. They
+    /// are drained into `buf` in stream order after each block, and kept
+    /// around to reuse their allocation across blocks.
+    stream_bufs: [Vec<Match>; OVERLAPPING_STREAMS - 1],
+    /// Whether the region being scanned looks dense with candidates, as
+    /// determined by the most recent block scan. Dense blocks are scanned
+    /// with interleaved streams (the prefilter can't skip anything anyway,
+    /// and interleaving hides the latency of the transition table accesses),
+    /// while sparse blocks are scanned byte-at-a-time so that the prefilter
+    /// is consulted at every visit to a start state, just like the
+    /// byte-at-a-time search does. When no prefilter exists, there is nothing
+    /// to skip with and blocks are always scanned interleaved.
+    dense: bool,
+}
+
+/// The number of independent automaton walks that are interleaved to scan a
+/// block of the haystack in `FindOverlappingIter`.
+const OVERLAPPING_STREAMS: usize = 4;
+
+/// The number of haystack bytes consumed by a single block scan in
+/// `FindOverlappingIter`. Matches are buffered one block at a time, so this
+/// bounds both the buffer memory and the work done ahead of what the caller
+/// has asked for.
+const OVERLAPPING_BLOCK: usize = 64 * 1024;
+
+impl<'a, 'h, A: Automaton> FindOverlappingIter<'a, 'h, A> {
+    fn new(
+        aut: &'a A,
+        input: Input<'h>,
+    ) -> Result<FindOverlappingIter<'a, 'h, A>, MatchError> {
+        if !aut.match_kind().is_standard() {
+            return Err(MatchError::unsupported_overlapping(aut.match_kind()));
+        }
+        //  We might consider lifting this restriction. The reason why I added
+        // it was to ban the combination of "anchored search" and "overlapping
+        // iteration." The match semantics aren't totally clear in that case.
+        // Should we allow *any* matches that are adjacent to *any* previous
+        // match? Or only following the most recent one? Or only matches
+        // that start at the beginning of the search? We might also elect to
+        // just keep this restriction in place, as callers should be able to
+        // implement it themselves if they want to.
+        if input.get_anchored().is_anchored() {
+            return Err(MatchError::invalid_input_anchored());
+        }
+        let start = aut.start_state(input.get_anchored())?;
+        let buffered = aut.prefers_interleaved_scan();
+        let mut buf = Vec::new();
+        let sid = if !buffered || input.is_done() {
+            None
+        } else {
+            // Handle the case where the start state is a match state. That
+            // is, the empty string is in our automaton. These are the only
+            // matches not discovered by consuming a byte in 'refill' below.
+            if aut.is_match(start) {
+                for i in 0..aut.match_len(start) {
+                    buf.push(get_match(aut, start, i, input.start()));
+                }
+            }
+            Some(start)
+        };
+        let at = input.start();
+        Ok(FindOverlappingIter {
+            aut,
+            input,
+            state: OverlappingState::start(),
+            start,
+            at,
+            sid,
+            buf,
+            buf_next: 0,
+            stream_bufs: [Vec::new(), Vec::new(), Vec::new()],
+            dense: false,
+        })
+    }
+
+    /// Scans the next block of the haystack, filling `self.buf` with all of
+    /// the matches in it.
+    ///
+    /// To hide the latency of the transition table accesses (the table is
+    /// often larger than the CPU cache and every access depends on the
+    /// previous one), a block is split into `OVERLAPPING_STREAMS` chunks
+    /// that are scanned by interleaved independent automaton walks. This
+    /// is possible because an Aho-Corasick state can only depend on the
+    /// previous `max_pattern_len` bytes of input: each chunk's walk is warmed
+    /// up on the bytes immediately preceding its chunk before any of its
+    /// matches are recorded. Stitching the buffered matches back together in
+    /// chunk order yields exactly the matches, in the same order, that a
+    /// byte-at-a-time scan produces.
+    #[inline(never)]
+    fn refill(&mut self, sid: StateID) {
+        self.buf.clear();
+        self.buf_next = 0;
+        // Mirrors the prefilter handling of the byte-at-a-time search: a
+        // prefilter is only consulted while the search is in a start state,
+        // and either reports that no candidates remain (search over) or gives
+        // a position at or after 'at' to jump to.
+        if let Some(pre) = self.aut.prefilter() {
+            if self.aut.is_start(sid) {
+                let span = Span::from(self.at..self.input.end());
+                match pre.find_in(self.input.haystack(), span).into_option() {
+                    None => {
+                        self.sid = None;
+                        return;
+                    }
+                    Some(i) => self.at = i,
+                }
+            }
+        }
+        let block_end =
+            core::cmp::min(self.at + OVERLAPPING_BLOCK, self.input.end());
+        // Interleaved scanning is only used for automatons that benefit from
+        // it (see 'prefers_interleaved_scan'), and only pays off when each
+        // chunk is meaningfully bigger than the warm-up region it must scan
+        // first.
+        let warm = self.aut.max_pattern_len().saturating_sub(1);
+        let chunk = (block_end - self.at) / OVERLAPPING_STREAMS;
+        let can_interleave = self.aut.prefers_interleaved_scan()
+            && chunk >= core::cmp::max(2 * warm, 64);
+        if !can_interleave || (self.aut.prefilter().is_some() && !self.dense) {
+            // Scan byte-at-a-time so that the prefilter keeps skipping at
+            // every visit to a start state. This loops over blocks internally
+            // (instead of returning to the iterator after each one) so that a
+            // long sparse region is traversed by a single tight loop, just
+            // like the byte-at-a-time search traverses it. If the prefilter
+            // could not skip most of a block (the region is dense with
+            // candidates), switch to interleaved scanning for the following
+            // blocks, until a block without any matches demotes us back
+            // below.
+            let mut sid = sid;
+            loop {
+                let scan_start = self.at;
+                let block_end = core::cmp::min(
+                    self.at + OVERLAPPING_BLOCK,
+                    self.input.end(),
+                );
+                let stepped = self.scan_serial(sid, block_end);
+                self.dense =
+                    stepped.saturating_mul(2) >= block_end - scan_start;
+                if (self.dense && can_interleave)
+                    || !self.buf.is_empty()
+                    || self.at >= self.input.end()
+                {
+                    return;
+                }
+                sid = match self.sid {
+                    None => return,
+                    Some(sid) => sid,
+                };
+            }
+        }
+        let hay = self.input.haystack();
+        let start = self.at;
+        let mut sids = [sid; OVERLAPPING_STREAMS];
+        for k in 1..OVERLAPPING_STREAMS {
+            let s = start + k * chunk;
+            let w = core::cmp::max(self.input.start(), s.saturating_sub(warm));
+            let mut lane = self.start;
+            for i in w..s {
+                lane = self.aut.next_state(Anchored::No, lane, hay[i]);
+            }
+            sids[k] = lane;
+        }
+        for j in 0..chunk {
+            sids[0] =
+                self.aut.next_state(Anchored::No, sids[0], hay[start + j]);
+            if self.aut.is_match(sids[0]) {
+                for i in 0..self.aut.match_len(sids[0]) {
+                    self.buf.push(get_match(
+                        self.aut,
+                        sids[0],
+                        i,
+                        start + j + 1,
+                    ));
+                }
+            }
+            for k in 1..OVERLAPPING_STREAMS {
+                let at = start + k * chunk + j;
+                sids[k] = self.aut.next_state(Anchored::No, sids[k], hay[at]);
+                if self.aut.is_match(sids[k]) {
+                    for i in 0..self.aut.match_len(sids[k]) {
+                        self.stream_bufs[k - 1].push(get_match(
+                            self.aut,
+                            sids[k],
+                            i,
+                            at + 1,
+                        ));
+                    }
+                }
+            }
+        }
+        // When the block isn't evenly divisible, the remainder continues on
+        // the last stream's state (and buffer, to keep matches in order).
+        let mut last = sids[OVERLAPPING_STREAMS - 1];
+        for at in (start + OVERLAPPING_STREAMS * chunk)..block_end {
+            last = self.aut.next_state(Anchored::No, last, hay[at]);
+            if self.aut.is_match(last) {
+                for i in 0..self.aut.match_len(last) {
+                    self.stream_bufs[OVERLAPPING_STREAMS - 2].push(get_match(
+                        self.aut,
+                        last,
+                        i,
+                        at + 1,
+                    ));
+                }
+            }
+        }
+        // A dead state means "the search is over": a byte-at-a-time scan
+        // stops at the first dead transition and reports nothing after it,
+        // but interleaved streams can't know that the chunks after a death
+        // are unreachable. So redo the block serially, which handles death
+        // correctly. (Dead states are believed to be unreachable here, since
+        // unanchored searches with the automatons in this crate never lead
+        // to a dead state, but correctness must not depend on that.)
+        let died = self.aut.is_dead(last)
+            || sids.iter().any(|&s| self.aut.is_dead(s));
+        if died {
+            self.buf.clear();
+            for b in self.stream_bufs.iter_mut() {
+                b.clear();
+            }
+            self.at = start;
+            self.dense = false;
+            self.scan_serial(sid, block_end);
+            return;
+        }
+        for k in 0..(OVERLAPPING_STREAMS - 1) {
+            self.buf.append(&mut self.stream_bufs[k]);
+        }
+        // A block without a single match suggests the region is sparse after
+        // all: go back to byte-at-a-time scanning so the prefilter gets a
+        // chance to skip.
+        self.dense = !self.buf.is_empty();
+        self.at = block_end;
+        self.sid = Some(last);
+    }
+
+    /// Scans up to `block_end` with a single byte-at-a-time automaton walk,
+    /// mirroring `try_find_overlapping_fwd_imp` (except that matches are
+    /// buffered instead of returned one at a time).
+    ///
+    /// Returns the number of bytes the automaton actually stepped through,
+    /// as opposed to bytes skipped over by the prefilter. A high ratio of
+    /// stepped bytes means the prefilter isn't effective on this region.
+    fn scan_serial(&mut self, mut sid: StateID, block_end: usize) -> usize {
+        let hay = self.input.haystack();
+        let mut stepped = 0;
+        while self.at < block_end {
+            sid = self.aut.next_state(Anchored::No, sid, hay[self.at]);
+            if self.aut.is_special(sid) {
+                if self.aut.is_dead(sid) {
+                    self.sid = None;
+                    return stepped;
+                } else if self.aut.is_match(sid) {
+                    for i in 0..self.aut.match_len(sid) {
+                        self.buf.push(get_match(
+                            self.aut,
+                            sid,
+                            i,
+                            self.at + 1,
+                        ));
+                    }
+                } else if let Some(pre) = self.aut.prefilter() {
+                    // A special state that is neither dead nor a match while
+                    // a prefilter is active must be a start state.
+                    debug_assert!(self.aut.is_start(sid));
+                    let span = Span::from(self.at..self.input.end());
+                    match pre.find_in(hay, span).into_option() {
+                        None => {
+                            self.sid = None;
+                            return stepped;
+                        }
+                        Some(i) => {
+                            if i > self.at {
+                                self.at = i;
+                                continue;
+                            }
+                        }
+                    }
+                }
+            }
+            self.at += 1;
+            stepped += 1;
+        }
+        self.sid = Some(sid);
+        stepped
+    }
 }
 
 impl<'a, 'h, A: Automaton> Iterator for FindOverlappingIter<'a, 'h, A> {
@@ -962,6 +1272,51 @@ impl<'a, 'h, A: Automaton> Iterator for FindOverlappingIter<'a, 'h, A> {
 
     #[inline(always)]
     fn next(&mut self) -> Option<Match> {
+        // Serve buffered matches before any dispatch, so that the per-match
+        // hot path of the buffered (DFA) mode is identical to a plain buffer
+        // pop. Non-buffered automatons never put anything in 'buf', so for
+        // them this is a single always-false comparison.
+        if self.buf_next < self.buf.len() {
+            let m = self.buf[self.buf_next];
+            self.buf_next += 1;
+            return Some(m);
+        }
+        // For concrete automaton types this is a constant, so one of the two
+        // arms below is compiled away entirely.
+        if self.aut.prefers_interleaved_scan() {
+            self.next_buffered()
+        } else {
+            self.next_byte_at_a_time()
+        }
+    }
+}
+
+impl<'a, 'h, A: Automaton> FindOverlappingIter<'a, 'h, A> {
+    /// Advances the buffered block scanner until it has matches to yield (or
+    /// the search is over). Only used for automatons that prefer interleaved
+    /// scanning (the DFA).
+    fn next_buffered(&mut self) -> Option<Match> {
+        loop {
+            let sid = self.sid?;
+            if self.at >= self.input.end() {
+                self.sid = None;
+                return None;
+            }
+            self.refill(sid);
+            if self.buf_next < self.buf.len() {
+                let m = self.buf[self.buf_next];
+                self.buf_next += 1;
+                return Some(m);
+            }
+        }
+    }
+
+    /// Yields the next match directly from the byte-at-a-time resumable
+    /// search, with no buffering. Used for automatons that do not prefer
+    /// interleaved scanning (the NFAs), for which this is the exact code
+    /// path that predates the block scanner.
+    #[inline(always)]
+    fn next_byte_at_a_time(&mut self) -> Option<Match> {
         self.aut
             .try_find_overlapping(&self.input, &mut self.state)
             .expect("already checked that no match error can occur here");
@@ -1605,4 +1960,70 @@ pub(crate) fn sparse_transitions<'a>(
         }
         None
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{string::String, vec, vec::Vec};
+
+    use super::*;
+    use crate::{
+        dfa,
+        nfa::{contiguous, noncontiguous},
+    };
+
+    // Collects all overlapping matches using the byte-at-a-time resumable
+    // search, which serves as the ground truth for the block-scanning
+    // iterator.
+    fn byte_at_a_time<A: Automaton>(aut: &A, hay: &[u8]) -> Vec<Match> {
+        let mut out = vec![];
+        let input = Input::new(hay);
+        let mut state = OverlappingState::start();
+        loop {
+            aut.try_find_overlapping(&input, &mut state).unwrap();
+            match state.get_match() {
+                None => break,
+                Some(m) => out.push(m),
+            }
+        }
+        out
+    }
+
+    fn iter_all<A: Automaton>(aut: &A, hay: &[u8]) -> Vec<Match> {
+        aut.try_find_overlapping_iter(Input::new(hay)).unwrap().collect()
+    }
+
+    #[test]
+    fn overlapping_iter_matches_byte_at_a_time() {
+        let sets: &[&[&str]] = &[
+            &["abc", "bc", "c", "b", "zzz"],
+            &["", "a", "abcd"],
+            &["aaa", "aa", "a"],
+            &["0123", "123 ", "23", "x"],
+        ];
+        let base = "abc bc zabcd 0123456 aaaa x";
+        let mut hays: Vec<String> =
+            vec![String::new(), String::from("a"), String::from(base)];
+        // Sizes that exercise the serial path, the interleaved path and both
+        // sides of block and chunk boundaries.
+        for len in [500, 16 * 1024, 64 * 1024 - 3, 64 * 1024, 200 * 1024] {
+            hays.push(base.repeat(1 + len / base.len()));
+        }
+        for &pats in sets {
+            let dfa_pre = dfa::DFA::new(pats).unwrap();
+            let mut builder = dfa::DFA::builder();
+            builder.prefilter(false);
+            let dfa_nopre = builder.build(pats).unwrap();
+            let nnfa = noncontiguous::NFA::new(pats).unwrap();
+            let cnfa = contiguous::NFA::new(pats).unwrap();
+            for hay in hays.iter() {
+                let hay = hay.as_bytes();
+                let want = byte_at_a_time(&dfa_pre, hay);
+                assert_eq!(want, iter_all(&dfa_pre, hay));
+                assert_eq!(want, iter_all(&dfa_nopre, hay));
+                assert_eq!(want, iter_all(&nnfa, hay));
+                assert_eq!(want, iter_all(&cnfa, hay));
+            }
+        }
+    }
 }

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -93,13 +93,23 @@ pub struct DFA {
     /// instead of the IDs being 0, 1, 2, 3, ..., they are 0*stride, 1*stride,
     /// 2*stride, 3*stride, ...
     trans: Vec<StateID>,
-    /// The matches for every match state in this DFA. This is first indexed by
-    /// state index (so that's `sid >> stride2`) and then by order in which the
-    /// matches are meant to occur.
-    matches: Vec<Vec<PatternID>>,
-    /// The amount of heap memory used, in bytes, by the inner Vecs of
-    /// 'matches'.
-    matches_memory_usage: usize,
+    /// The matches for every match state in this DFA, in one contiguous
+    /// allocation. The matches for the state whose index (that's
+    /// `sid >> stride2`, less 2 for the dead and fail states) is `i` are given
+    /// by `matches[match_offsets[i]..match_offsets[i + 1]]`, in the order in
+    /// which the matches are meant to occur.
+    matches: Vec<PatternID>,
+    /// The offsets into 'matches' for every match state in this DFA, indexed
+    /// by state index. This always has a length equal to the number of match
+    /// states plus one.
+    ///
+    /// A `u32` is always big enough for these offsets: the total number of
+    /// matches in a DFA is at most twice (for `StartKind::Both`, which
+    /// duplicates every match state) the number of matches in the
+    /// noncontiguous NFA it was built from, and NFA construction returns an
+    /// error if that number would exceed `StateID::LIMIT`. Since
+    /// `2 * StateID::LIMIT < u32::MAX`, these offsets never overflow.
+    match_offsets: Vec<u32>,
     /// The length of each pattern. This is used to compute the start offset
     /// of a match.
     pattern_lens: Vec<SmallIndex>,
@@ -166,20 +176,28 @@ impl DFA {
     /// than the NFAs in this crate.
     const DEAD: StateID = StateID::new_unchecked(0);
 
-    /// Adds the given pattern IDs as matches to the given state and also
-    /// records the added memory usage.
+    /// Adds the given pattern IDs as matches to the given state.
+    ///
+    /// This must be called for match states in ascending order of state
+    /// index, since the pattern IDs are appended to a single contiguous
+    /// allocation shared by all match states.
     fn set_matches(
         &mut self,
         sid: StateID,
         pids: impl Iterator<Item = PatternID>,
     ) {
         let index = (sid.as_usize() >> self.stride2).checked_sub(2).unwrap();
+        assert_eq!(
+            self.match_offsets[index].as_usize(),
+            self.matches.len(),
+            "match states must be set in ascending order",
+        );
         let mut at_least_one = false;
         for pid in pids {
-            self.matches[index].push(pid);
-            self.matches_memory_usage += PatternID::SIZE;
+            self.matches.push(pid);
             at_least_one = true;
         }
+        self.match_offsets[index + 1] = self.matches.len().as_u32();
         assert!(at_least_one, "match state must have non-empty pids");
     }
 }
@@ -275,14 +293,17 @@ unsafe impl Automaton for DFA {
     fn match_len(&self, sid: StateID) -> usize {
         debug_assert!(self.is_match(sid));
         let offset = (sid.as_usize() >> self.stride2) - 2;
-        self.matches[offset].len()
+        (self.match_offsets[offset + 1] - self.match_offsets[offset])
+            .as_usize()
     }
 
     #[inline(always)]
     fn match_pattern(&self, sid: StateID, index: usize) -> PatternID {
         debug_assert!(self.is_match(sid));
         let offset = (sid.as_usize() >> self.stride2) - 2;
-        self.matches[offset][index]
+        let start = self.match_offsets[offset].as_usize();
+        let end = self.match_offsets[offset + 1].as_usize();
+        self.matches[start..end][index]
     }
 
     #[inline(always)]
@@ -290,8 +311,8 @@ unsafe impl Automaton for DFA {
         use core::mem::size_of;
 
         (self.trans.len() * size_of::<u32>())
-            + (self.matches.len() * size_of::<Vec<PatternID>>())
-            + self.matches_memory_usage
+            + (self.matches.len() * PatternID::SIZE)
+            + (self.match_offsets.len() * size_of::<u32>())
             + (self.pattern_lens.len() * size_of::<SmallIndex>())
             + self.prefilter.as_ref().map_or(0, |p| p.memory_usage())
     }
@@ -491,8 +512,8 @@ impl Builder {
         };
         let mut dfa = DFA {
             trans: vec![DFA::DEAD; trans_len],
-            matches: vec![vec![]; num_match_states],
-            matches_memory_usage: 0,
+            matches: vec![],
+            match_offsets: vec![0; num_match_states + 1],
             pattern_lens: nnfa.pattern_lens_raw().to_vec(),
             prefilter: nnfa.prefilter().cloned(),
             match_kind: nnfa.match_kind(),
@@ -524,18 +545,27 @@ impl Builder {
             dfa.byte_classes.alphabet_len(),
             dfa.byte_classes.stride(),
         );
+        // For 'StartKind::Both' when the empty pattern is one of the patterns
+        // given, the number of match states allocated above can exceed the
+        // number of match states actually created. (This is because the start
+        // states are match states in that case, but are not duplicated like
+        // other match states are.) The offsets of any unused trailing slots
+        // are never set above, so we set them here such that they would
+        // correspond to empty slices of 'dfa.matches'. (They should never be
+        // read, since the slots don't correspond to any match state, but this
+        // way, the invariant 'match_offsets[i] <= match_offsets[i + 1]' holds
+        // for the entire table.)
+        for i in 1..dfa.match_offsets.len() {
+            if dfa.match_offsets[i] < dfa.match_offsets[i - 1] {
+                dfa.match_offsets[i] = dfa.match_offsets[i - 1];
+            }
+        }
         // The vectors can grow ~twice as big during construction because a
         // Vec amortizes growth. But here, let's shrink things back down to
         // what we actually need since we're never going to add more to it.
         dfa.trans.shrink_to_fit();
         dfa.pattern_lens.shrink_to_fit();
         dfa.matches.shrink_to_fit();
-        // TODO: We might also want to shrink each Vec inside of `dfa.matches`,
-        // or even better, convert it to one contiguous allocation. But I think
-        // I went with nested allocs for good reason (can't remember), so this
-        // may be tricky to do. I decided not to shrink them here because it
-        // might require a fair bit of work to do. It's unclear whether it's
-        // worth it.
         Ok(dfa)
     }
 

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -95,7 +95,7 @@ pub struct DFA {
     trans: Vec<StateID>,
     /// The matches for every match state in this DFA, in one contiguous
     /// allocation. The matches for the state whose index (that's
-    /// `sid >> stride2`, less 2 for the dead and fail states) is `i` are given
+    /// `sid / stride`, less 2 for the dead and fail states) is `i` are given
     /// by `matches[match_offsets[i]..match_offsets[i + 1]]`, in the order in
     /// which the matches are meant to occur.
     matches: Vec<PatternID>,
@@ -120,15 +120,27 @@ pub struct DFA {
     /// The total number of states in this DFA.
     state_len: usize,
     /// The alphabet size, or total number of equivalence classes, for this
-    /// DFA. Note that the actual number of transitions in each state is
-    /// stride=2^stride2, where stride is the smallest power of 2 greater than
-    /// or equal to alphabet_len. We do things this way so that we can use
-    /// bitshifting to go from a state ID to an index into 'matches'.
+    /// DFA.
     alphabet_len: usize,
-    /// The exponent with a base 2, such that stride=2^stride2. Given a state
-    /// index 'i', its state identifier is 'i << stride2'. Given a state
-    /// identifier 'sid', its state index is 'sid >> stride2'.
-    stride2: usize,
+    /// The stride: the number of transitions in each state's row of the
+    /// transition table. Given a state index 'i', its state identifier is
+    /// 'i * stride'. Given a state identifier 'sid', its state index is
+    /// 'sid / stride'.
+    ///
+    /// For a small transition table (which is usually cache resident), this
+    /// is 'alphabet_len' rounded up to a power of 2, which keeps every row
+    /// aligned to (and thus within) as few cache lines as possible. For a
+    /// big table, this is exactly 'alphabet_len': the (up to ~2x) memory
+    /// saved matters much more there, since search speed is then dominated
+    /// by cache misses that a smaller table alleviates.
+    stride: usize,
+    /// The constants used to recover a state index from a (premultiplied)
+    /// state ID without a division: with 'stride = 2^stride_shift * odd' and
+    /// 'stride_inv = odd^-1 mod 2^32', the index of 'sid' is
+    /// '(sid >> stride_shift) * stride_inv mod 2^32'. This is exact because
+    /// a state ID is always an exact multiple of the stride.
+    stride_shift: u32,
+    stride_inv: u32,
     /// The equivalence classes for this DFA. All transitions are defined on
     /// equivalence classes and not on the 256 distinct byte values.
     byte_classes: ByteClasses,
@@ -176,6 +188,22 @@ impl DFA {
     /// than the NFAs in this crate.
     const DEAD: StateID = StateID::new_unchecked(0);
 
+    /// Returns the index of the state with the given (premultiplied) ID.
+    ///
+    /// Since state IDs are premultiplied by the stride, this is a division
+    /// by the stride. The stride isn't necessarily a power of 2, but the
+    /// division is always exact (IDs are exact multiples of the stride), so
+    /// it can be done with a shift and a multiplication by the inverse of
+    /// the stride's odd factor, both precomputed at build time. This matters
+    /// because this is called for every match found by a search: an actual
+    /// division here measurably slows down match-heavy workloads.
+    #[inline(always)]
+    fn state_index(&self, sid: StateID) -> usize {
+        (sid.as_u32() >> self.stride_shift)
+            .wrapping_mul(self.stride_inv)
+            .as_usize()
+    }
+
     /// Adds the given pattern IDs as matches to the given state.
     ///
     /// This must be called for match states in ascending order of state
@@ -186,7 +214,7 @@ impl DFA {
         sid: StateID,
         pids: impl Iterator<Item = PatternID>,
     ) {
-        let index = (sid.as_usize() >> self.stride2).checked_sub(2).unwrap();
+        let index = self.state_index(sid).checked_sub(2).unwrap();
         assert_eq!(
             self.match_offsets[index].as_usize(),
             self.matches.len(),
@@ -292,7 +320,7 @@ unsafe impl Automaton for DFA {
     #[inline(always)]
     fn match_len(&self, sid: StateID) -> usize {
         debug_assert!(self.is_match(sid));
-        let offset = (sid.as_usize() >> self.stride2) - 2;
+        let offset = self.state_index(sid) - 2;
         (self.match_offsets[offset + 1] - self.match_offsets[offset])
             .as_usize()
     }
@@ -300,7 +328,7 @@ unsafe impl Automaton for DFA {
     #[inline(always)]
     fn match_pattern(&self, sid: StateID, index: usize) -> PatternID {
         debug_assert!(self.is_match(sid));
-        let offset = (sid.as_usize() >> self.stride2) - 2;
+        let offset = self.state_index(sid) - 2;
         let start = self.match_offsets[offset].as_usize();
         let end = self.match_offsets[offset + 1].as_usize();
         self.matches[start..end][index]
@@ -332,7 +360,7 @@ impl core::fmt::Debug for DFA {
 
         writeln!(f, "dfa::DFA(")?;
         for index in 0..self.state_len {
-            let sid = StateID::new_unchecked(index << self.stride2);
+            let sid = StateID::new_unchecked(index * self.stride);
             // While we do currently include the FAIL state in the transition
             // table (to simplify construction), it is never actually used. It
             // poses problems with the code below because it gets treated as
@@ -393,7 +421,7 @@ impl core::fmt::Debug for DFA {
         writeln!(f, "shortest pattern length: {:?}", self.min_pattern_len)?;
         writeln!(f, "longest pattern length: {:?}", self.max_pattern_len)?;
         writeln!(f, "alphabet length: {:?}", self.alphabet_len)?;
-        writeln!(f, "stride: {:?}", 1 << self.stride2)?;
+        writeln!(f, "stride: {:?}", self.stride)?;
         writeln!(f, "byte classes: {:?}", self.byte_classes)?;
         writeln!(f, "memory usage: {:?}", self.memory_usage())?;
         writeln!(f, ")")?;
@@ -480,23 +508,39 @@ impl Builder {
                     .unwrap()
             }
         };
-        let trans_len =
-            match state_len.checked_shl(byte_classes.stride2().as_u32()) {
-                Some(trans_len) => trans_len,
-                None => {
-                    return Err(BuildError::state_id_overflow(
-                        StateID::MAX.as_u64(),
-                        usize::MAX.as_u64(),
-                    ))
-                }
-            };
-        StateID::new(trans_len.checked_sub(byte_classes.stride()).unwrap())
-            .map_err(|e| {
-                BuildError::state_id_overflow(
+        // Small transition tables are usually cache resident, where keeping
+        // every row cache-line aligned (by rounding the stride up to a power
+        // of 2) measurably helps search speed and the padding costs at most
+        // 64KB. For bigger tables, an exact stride can shrink the table by
+        // up to ~2x, which matters much more: their search speed is
+        // dominated by cache misses, which a smaller table alleviates.
+        let stride = {
+            let pow2 = byte_classes.alphabet_len().next_power_of_two();
+            let pow2_table_bytes = state_len
+                .checked_mul(pow2)
+                .and_then(|len| len.checked_mul(StateID::SIZE));
+            match pow2_table_bytes {
+                Some(bytes) if bytes <= 128 * 1024 => pow2,
+                _ => byte_classes.alphabet_len(),
+            }
+        };
+        // The constants for recovering a state index from a premultiplied
+        // state ID with a shift and a multiplication instead of a division.
+        // See 'DFA::state_index' for how they are used.
+        let stride_shift = stride.trailing_zeros();
+        let stride_inv = mod32_inverse((stride >> stride_shift).as_u32());
+        let trans_len = match state_len.checked_mul(stride) {
+            Some(trans_len) => trans_len,
+            None => {
+                return Err(BuildError::state_id_overflow(
                     StateID::MAX.as_u64(),
-                    e.attempted(),
-                )
-            })?;
+                    usize::MAX.as_u64(),
+                ))
+            }
+        };
+        StateID::new(trans_len.checked_sub(stride).unwrap()).map_err(|e| {
+            BuildError::state_id_overflow(StateID::MAX.as_u64(), e.attempted())
+        })?;
         let num_match_states = match self.start_kind {
             StartKind::Unanchored | StartKind::Anchored => {
                 nnfa.special().max_match_id.as_usize().checked_sub(1).unwrap()
@@ -519,7 +563,9 @@ impl Builder {
             match_kind: nnfa.match_kind(),
             state_len,
             alphabet_len: byte_classes.alphabet_len(),
-            stride2: byte_classes.stride2(),
+            stride,
+            stride_shift,
+            stride_inv,
             byte_classes,
             min_pattern_len: nnfa.min_pattern_len(),
             max_pattern_len: nnfa.max_pattern_len(),
@@ -543,7 +589,7 @@ impl Builder {
             dfa.state_len,
             dfa.memory_usage(),
             dfa.byte_classes.alphabet_len(),
-            dfa.byte_classes.stride(),
+            dfa.stride,
         );
         // For 'StartKind::Both' when the empty pattern is one of the patterns
         // given, the number of match states allocated above can exceed the
@@ -579,9 +625,9 @@ impl Builder {
     ) {
         // This function always succeeds because we check above that all of the
         // states in the NFA can be mapped to DFA state IDs.
-        let stride2 = dfa.stride2;
+        let stride = dfa.stride;
         let old2new = |oldsid: StateID| {
-            StateID::new_unchecked(oldsid.as_usize() << stride2)
+            StateID::new_unchecked(oldsid.as_usize() * stride)
         };
         for (oldsid, state) in nnfa.states().iter().with_state_ids() {
             let newsid = old2new(oldsid);
@@ -649,8 +695,7 @@ impl Builder {
         nnfa: &noncontiguous::NFA,
         dfa: &mut DFA,
     ) {
-        let stride2 = dfa.stride2;
-        let stride = 1 << stride2;
+        let stride = dfa.stride;
         let mut remap_unanchored = vec![DFA::DEAD; nnfa.states().len()];
         let mut remap_anchored = vec![DFA::DEAD; nnfa.states().len()];
         let mut is_anchored = vec![false; dfa.state_len];
@@ -673,7 +718,7 @@ impl Builder {
                 } else {
                     remap_unanchored[oldsid] = DFA::DEAD;
                     remap_anchored[oldsid] = newsid;
-                    is_anchored[newsid.as_usize() >> stride2] = true;
+                    is_anchored[newsid.as_usize() / stride] = true;
                 }
                 if state.is_match() {
                     dfa.set_matches(newsid, nnfa.iter_matches(oldsid));
@@ -700,7 +745,7 @@ impl Builder {
 
                 remap_unanchored[oldsid] = unewsid;
                 remap_anchored[oldsid] = anewsid;
-                is_anchored[anewsid.as_usize() >> stride2] = true;
+                is_anchored[anewsid.as_usize() / stride] = true;
                 if state.is_match() {
                     dfa.set_matches(unewsid, nnfa.iter_matches(oldsid));
                     dfa.set_matches(anewsid, nnfa.iter_matches(oldsid));
@@ -732,7 +777,7 @@ impl Builder {
             }
         }
         for i in 0..dfa.state_len {
-            let sid = i << stride2;
+            let sid = i * stride;
             if is_anchored[i] {
                 for next in dfa.trans[sid..][..stride].iter_mut() {
                     *next = remap_anchored[*next];
@@ -817,6 +862,24 @@ impl Builder {
         self.byte_classes = yes;
         self
     }
+}
+
+/// Returns the multiplicative inverse of `n` modulo `2^32`, where `n` must
+/// be odd (an inverse only exists for odd numbers).
+///
+/// This uses Newton's method: starting from an approximation `x` of the
+/// inverse that is correct on its lowest `k` bits, `x * (2 - n * x)` is
+/// correct on its lowest `2k` bits. `x = n` is always correct on the lowest
+/// 3 bits (for odd `n`, `n * n = 1 mod 8`), so five iterations are enough
+/// to be correct on all 32 bits.
+fn mod32_inverse(n: u32) -> u32 {
+    assert_eq!(n % 2, 1, "multiplicative inverse requires an odd number");
+    let mut inv = n;
+    for _ in 0..5 {
+        inv = inv.wrapping_mul(2u32.wrapping_sub(n.wrapping_mul(inv)));
+    }
+    debug_assert_eq!(n.wrapping_mul(inv), 1);
+    inv
 }
 
 /// Iterate over all possible equivalence class transitions in this state.

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -349,6 +349,11 @@ unsafe impl Automaton for DFA {
     fn prefilter(&self) -> Option<&Prefilter> {
         self.prefilter.as_ref()
     }
+
+    #[inline(always)]
+    fn prefers_interleaved_scan(&self) -> bool {
+        true
+    }
 }
 
 impl core::fmt::Debug for DFA {


### PR DESCRIPTION
**disclaimer**: all code created by Claude Opus/Fable

### Description

While playing with [yara-x](https://github.com/VirusTotal/yara-x) or [boreal](https://github.com/vthib/boreal) and checking if performances can be improved (compared with stock Yara library), asked Claude to implement a few ideas to save on RAM and CPU:
- flatten vec<vec<X>> to avoid vec metadata on heap and potentially improve cache locality
- reduce DFA transition table to actual size (instead of next power of 2) for tables above a certain threshold
- kind of paralellize DFA by using 4 interleaved streams


### Benchmarks

Boreal with DFA (boreal-speed) yielded around 10-40% improvement over current version

```
  signature-base (4 297 rules, 16 035 AC patterns)

  ┌──────────────────────────┬──────────────┬───────────────┬─────────────┬──────────────┐
  │          engine          │ vulkan-1.dll │ libGLESv2.dll │ firefox.msi │ ui_tests.exe │
  ├──────────────────────────┼──────────────┼───────────────┼─────────────┼──────────────┤
  │ boreal-speed · workdir   │ 8.42 ms      │ 44.5 ms       │ 380.9 ms    │ 1.207 s      │
  ├──────────────────────────┼──────────────┼───────────────┼─────────────┼──────────────┤
  │ boreal-speed · upstream  │ 9.13 ms      │ 47.8 ms       │ 652.6 ms    │ 1.364 s      │
  ├──────────────────────────┼──────────────┼───────────────┼─────────────┼────────


```

micro benchmark run by Claude

```
> run benches between current version and stock upstream version and compare CPU between the 2                                                                                                                                                                                                                                                             
   
  Ran 3 shell commands 

● CPU comparison complete — your clone's three commits reproduce the validated numbers exactly. Same window, same inputs, identical match counts on every test:

  ┌───────────────────────────────────────┬─────────────┬─────────────────────┬───────────────────────────────────────────────────────────┐
  │               CPU test                │ Stock 1.1.4 │ Current (3 commits) │                             Δ                             │
  ├───────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────────────────────┤
  │ DFA 100k overlapping, match-heavy     │     30 MB/s │            137 MB/s │ +4.6×                                                     │
  ├───────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────────────────────┤
  │ DFA 100k find_iter, match-heavy       │     46 MB/s │             66 MB/s │ +43%                                                      │
  ├───────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────────────────────┤
  │ DFA 7k find_iter, match-heavy         │    278 MB/s │            298 MB/s │ +7%                                                       │
  ├───────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────────────────────┤
  │ DFA 7k overlapping, match-heavy       │    358 MB/s │            372 MB/s │ +4%                                                       │
  ├───────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────────────────────┤
  │ DFA build, 100k patterns              │     76.4 ms │             75.7 ms │ ~noise                                                    │
  ├───────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────────────────────┤
  │ DFA 7k overlapping, sparse candidates │   35.9 GB/s │           36.8 GB/s │ noise                                                     │
  ├───────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────────────────────┤
  │ DFA 7k overlapping, pure junk         │   43.9 GB/s │           52.1 GB/s │ noise band (prefilter-bound, swings both ways run to run) │
  ├───────────────────────────────────────┼─────────────┼─────────────────────┼───────────────────────────────────────────────────────────┤
  │ NFA 7k overlapping, match-heavy       │    239 MB/s │            236 MB/s │ noise (NFA runs the unchanged legacy path)                │
  └───────────────────────────────────────┴─────────────┴─────────────────────┴───────────────────────────────────────────────────────────┘

  Reading: the two big wins land where the changes aim — large-table workloads. The +43% on find_iter comes from the hybrid-stride table (23 MB → 14 MB, fewer cache misses per transition), and the +4.6× on overlapping stacks the 4-stream interleaved scanner on top of that. Mid-size DFAs pick up single-digit gains from the flattened match
  storage; everything that shouldn't change (NFA paths, prefilter-dominated scans, sparse inputs) sits in the noise band, matching the earlier deep verification where each apparent outlier was eliminated by same-source control builds.
```

### Notes

If the PR is not to your liking (coding standards, ..) but you find the ideas/improvements interesting, don't hesitate to close it and  do a clean one instead