### PR TITLE
flatten matches storage for DFA to reduce heap usage

### DIFF
--- a/src/ahocorasick.rs
+++ b/src/ahocorasick.rs
@@ -1982,14 +1982,14 @@ impl AhoCorasick {
     ///     .kind(None) // default
     ///     .build(&["foobar", "bruce", "triskaidekaphobia", "springsteen"])
     ///     .unwrap();
-    /// assert_eq!(5_632, ac.memory_usage());
+    /// assert_eq!(5_556, ac.memory_usage());
     ///
     /// let ac = AhoCorasick::builder()
     ///     .kind(None) // default
     ///     .ascii_case_insensitive(true)
     ///     .build(&["foobar", "bruce", "triskaidekaphobia", "springsteen"])
     ///     .unwrap();
-    /// assert_eq!(11_136, ac.memory_usage());
+    /// assert_eq!(11_060, ac.memory_usage());
     ///
     /// let ac = AhoCorasick::builder()
     ///     .kind(Some(AhoCorasickKind::NoncontiguousNFA))
@@ -2016,7 +2016,7 @@ impl AhoCorasick {
     /// // will reveal that the rate of growth of the DFA is far bigger than
     /// // the NFAs above. For a large number of patterns, it is easy for the
     /// // DFA to take an order of magnitude more heap space (or more!).
-    /// assert_eq!(11_136, ac.memory_usage());
+    /// assert_eq!(11_060, ac.memory_usage());
     /// ```
     pub fn memory_usage(&self) -> usize {
         self.aut.memory_usage()

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -93,13 +93,23 @@ pub struct DFA {
     /// instead of the IDs being 0, 1, 2, 3, ..., they are 0*stride, 1*stride,
     /// 2*stride, 3*stride, ...
     trans: Vec<StateID>,
-    /// The matches for every match state in this DFA. This is first indexed by
-    /// state index (so that's `sid >> stride2`) and then by order in which the
-    /// matches are meant to occur.
-    matches: Vec<Vec<PatternID>>,
-    /// The amount of heap memory used, in bytes, by the inner Vecs of
-    /// 'matches'.
-    matches_memory_usage: usize,
+    /// The matches for every match state in this DFA, in one contiguous
+    /// allocation. The matches for the state whose index (that's
+    /// `sid >> stride2`, less 2 for the dead and fail states) is `i` are given
+    /// by `matches[match_offsets[i]..match_offsets[i + 1]]`, in the order in
+    /// which the matches are meant to occur.
+    matches: Vec<PatternID>,
+    /// The offsets into 'matches' for every match state in this DFA, indexed
+    /// by state index. This always has a length equal to the number of match
+    /// states plus one.
+    ///
+    /// A `u32` is always big enough for these offsets: the total number of
+    /// matches in a DFA is at most twice (for `StartKind::Both`, which
+    /// duplicates every match state) the number of matches in the
+    /// noncontiguous NFA it was built from, and NFA construction returns an
+    /// error if that number would exceed `StateID::LIMIT`. Since
+    /// `2 * StateID::LIMIT < u32::MAX`, these offsets never overflow.
+    match_offsets: Vec<u32>,
     /// The length of each pattern. This is used to compute the start offset
     /// of a match.
     pattern_lens: Vec<SmallIndex>,
@@ -166,20 +176,28 @@ impl DFA {
     /// than the NFAs in this crate.
     const DEAD: StateID = StateID::new_unchecked(0);
 
-    /// Adds the given pattern IDs as matches to the given state and also
-    /// records the added memory usage.
+    /// Adds the given pattern IDs as matches to the given state.
+    ///
+    /// This must be called for match states in ascending order of state
+    /// index, since the pattern IDs are appended to a single contiguous
+    /// allocation shared by all match states.
     fn set_matches(
         &mut self,
         sid: StateID,
         pids: impl Iterator<Item = PatternID>,
     ) {
         let index = (sid.as_usize() >> self.stride2).checked_sub(2).unwrap();
+        assert_eq!(
+            self.match_offsets[index].as_usize(),
+            self.matches.len(),
+            "match states must be set in ascending order",
+        );
         let mut at_least_one = false;
         for pid in pids {
-            self.matches[index].push(pid);
-            self.matches_memory_usage += PatternID::SIZE;
+            self.matches.push(pid);
             at_least_one = true;
         }
+        self.match_offsets[index + 1] = self.matches.len().as_u32();
         assert!(at_least_one, "match state must have non-empty pids");
     }
 }
@@ -275,14 +293,17 @@ unsafe impl Automaton for DFA {
     fn match_len(&self, sid: StateID) -> usize {
         debug_assert!(self.is_match(sid));
         let offset = (sid.as_usize() >> self.stride2) - 2;
-        self.matches[offset].len()
+        (self.match_offsets[offset + 1] - self.match_offsets[offset])
+            .as_usize()
     }
 
     #[inline(always)]
     fn match_pattern(&self, sid: StateID, index: usize) -> PatternID {
         debug_assert!(self.is_match(sid));
         let offset = (sid.as_usize() >> self.stride2) - 2;
-        self.matches[offset][index]
+        let start = self.match_offsets[offset].as_usize();
+        let end = self.match_offsets[offset + 1].as_usize();
+        self.matches[start..end][index]
     }
 
     #[inline(always)]
@@ -290,8 +311,8 @@ unsafe impl Automaton for DFA {
         use core::mem::size_of;
 
         (self.trans.len() * size_of::<u32>())
-            + (self.matches.len() * size_of::<Vec<PatternID>>())
-            + self.matches_memory_usage
+            + (self.matches.len() * PatternID::SIZE)
+            + (self.match_offsets.len() * size_of::<u32>())
             + (self.pattern_lens.len() * size_of::<SmallIndex>())
             + self.prefilter.as_ref().map_or(0, |p| p.memory_usage())
     }
@@ -491,8 +512,8 @@ impl Builder {
         };
         let mut dfa = DFA {
             trans: vec![DFA::DEAD; trans_len],
-            matches: vec![vec![]; num_match_states],
-            matches_memory_usage: 0,
+            matches: vec![],
+            match_offsets: vec![0; num_match_states + 1],
             pattern_lens: nnfa.pattern_lens_raw().to_vec(),
             prefilter: nnfa.prefilter().cloned(),
             match_kind: nnfa.match_kind(),
@@ -524,18 +545,27 @@ impl Builder {
             dfa.byte_classes.alphabet_len(),
             dfa.byte_classes.stride(),
         );
+        // For 'StartKind::Both' when the empty pattern is one of the patterns
+        // given, the number of match states allocated above can exceed the
+        // number of match states actually created. (This is because the start
+        // states are match states in that case, but are not duplicated like
+        // other match states are.) The offsets of any unused trailing slots
+        // are never set above, so we set them here such that they would
+        // correspond to empty slices of 'dfa.matches'. (They should never be
+        // read, since the slots don't correspond to any match state, but this
+        // way, the invariant 'match_offsets[i] <= match_offsets[i + 1]' holds
+        // for the entire table.)
+        for i in 1..dfa.match_offsets.len() {
+            if dfa.match_offsets[i] < dfa.match_offsets[i - 1] {
+                dfa.match_offsets[i] = dfa.match_offsets[i - 1];
+            }
+        }
         // The vectors can grow ~twice as big during construction because a
         // Vec amortizes growth. But here, let's shrink things back down to
         // what we actually need since we're never going to add more to it.
         dfa.trans.shrink_to_fit();
         dfa.pattern_lens.shrink_to_fit();
         dfa.matches.shrink_to_fit();
-        // TODO: We might also want to shrink each Vec inside of `dfa.matches`,
-        // or even better, convert it to one contiguous allocation. But I think
-        // I went with nested allocs for good reason (can't remember), so this
-        // may be tricky to do. I decided not to shrink them here because it
-        // might require a fair bit of work to do. It's unclear whether it's
-        // worth it.
         Ok(dfa)
     }
 


### PR DESCRIPTION
**disclaimer**: all code created by Claude Opus/Fable

Follow up of https://github.com/BurntSushi/aho-corasick/pull/177

### Description

Flatten a vec of vec to reduce heap usage (heap metadata) and improve cache locality + slight performance improvements

(perf-2 is a follow-up MR that applies on top of this one, keeping both benchmarks at the same place for consistency)

Claude description of each (CPU + RAM) benchmark

_saves a fixed ~32 bytes per match state (the Vec header + separate allocation + growth slack), so its percentage tracks the match-state density: −12 to −18% on short-pattern sets where up to a quarter of states are match states, −3% on long-pattern sets where the transition table dominates._

_perf-1 (flatten) is a match-resolution win: +8% where matches are dense and the table is cache-resident (7k find_iter), +13% on 100k overlapping where every match state visit reads pattern IDs. It's exactly 0% on 100k find_iter — that workload is bounded by transition-table cache misses, which flattening doesn't touch. No CPU cost anywhere._

### Benchmark

```
RAM
  ┌────────────────┬────────────────┬─────────────────────┬─────────────────────────┐
  │  Pattern set   │ master (1.1.4) │  perf-1 (flatten)   │ perf-2 (+hybrid stride) │
  ├────────────────┼────────────────┼─────────────────────┼─────────────────────────┤
  │ 7k × 4-char    │      1,264,440 │  1,040,444 (−17.7%) │        651,900 (−48.4%) │
  ├────────────────┼────────────────┼─────────────────────┼─────────────────────────┤
  │ 100k × 5-char  │     26,148,504 │ 22,948,508 (−12.2%) │     14,113,292 (−46.0%) │
  ├────────────────┼────────────────┼─────────────────────┼─────────────────────────┤
  │ 20k × 16-char  │     21,645,336 │  21,005,340 (−3.0%) │     17,111,844 (−20.9%) │
  ├────────────────┼────────────────┼─────────────────────┼─────────────────────────┤
  │ 100k × 17-char │    108,223,128 │ 105,023,132 (−3.0%) │     85,556,300 (−20.9%) │
  └────────────────┴────────────────┴─────────────────────┴─────────────────────────┘


CPU

  ┌───────────────────────────────────┬───────────┬───────────┬───────────────────┐
  │             CPU test              │  master   │  perf-1   │      perf-2       │
  ├───────────────────────────────────┼───────────┼───────────┼───────────────────┤
  │ DFA 100k overlapping, match-heavy │   30 MB/s │ 34 (+13%) │         41 (+37%) │
  ├───────────────────────────────────┼───────────┼───────────┼───────────────────┤
  │ DFA 100k find_iter, match-heavy   │   58 MB/s │   58 (0%) │         68 (+17%) │
  ├───────────────────────────────────┼───────────┼───────────┼───────────────────┤
  │ DFA 7k find_iter, match-heavy     │  278 MB/s │ 301 (+8%) │         298 (+7%) │
  ├───────────────────────────────────┼───────────┼───────────┼───────────────────┤
  │ DFA 7k overlapping, match-heavy   │  351 MB/s │ 359 (+2%) │         375 (+7%) │
  ├───────────────────────────────────┼───────────┼───────────┼───────────────────┤
  │ DFA build, 100k patterns          │   78.2 ms │   78.6 ms │     76.6 ms (−2%) │
  ├───────────────────────────────────┼───────────┼───────────┼───────────────────┤
  │ DFA 7k overlapping, sparse        │ 35.3 GB/s │ 35.7 GB/s │ 37.0 GB/s (noise) │
  ├───────────────────────────────────┼───────────┼───────────┼───────────────────┤
  │ NFA 7k overlapping, match-heavy   │  237 MB/s │  236 MB/s │  238 MB/s (noise) │
  └───────────────────────────────────┴───────────┴───────────┴───────────────────┘

```

### Bencharmking code

RAM
```rust
use std::alloc::{GlobalAlloc, Layout, System};
  use std::sync::atomic::{AtomicUsize, Ordering};

  struct Counter;
  static LIVE: AtomicUsize = AtomicUsize::new(0);
  unsafe impl GlobalAlloc for Counter {
      unsafe fn alloc(&self, l: Layout) -> *mut u8 {
          LIVE.fetch_add(l.size(), Ordering::Relaxed);
          System.alloc(l)
      }
      unsafe fn alloc_zeroed(&self, l: Layout) -> *mut u8 {
          LIVE.fetch_add(l.size(), Ordering::Relaxed);
          System.alloc_zeroed(l)
      }
      unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
          LIVE.fetch_sub(l.size(), Ordering::Relaxed);
          System.dealloc(p, l)
      }
      unsafe fn realloc(&self, p: *mut u8, l: Layout, n: usize) -> *mut u8 {
          let np = System.realloc(p, l, n);
          if !np.is_null() {
              LIVE.fetch_add(n, Ordering::Relaxed);
              LIVE.fetch_sub(l.size(), Ordering::Relaxed);
          }
          np
      }
  }
  #[global_allocator]
  static A: Counter = Counter;

  use aho_corasick::dfa::DFA;

  fn main() {
      let sets: [(&str, u32, fn(u32) -> String); 4] = [
          ("7k x 4-char", 7_000, |i| format!("{:04x}", i)),
          ("100k x 5-char", 100_000, |i| format!("{:04x}{:x}", i % 65536, i / 65536)),
          ("20k x 16-char", 20_000, |i| format!("pat{:05}suffix{}", i, i % 7)),
          ("100k x 17-char", 100_000, |i| format!("pat{:06}suffix{}", i, i % 7)),
      ];
      for (name, n, f) in sets {
          let words: Vec<String> = (0..n).map(f).collect();
          let before = LIVE.load(Ordering::Relaxed);
          let dfa = DFA::new(&words).unwrap();
          let after = LIVE.load(Ordering::Relaxed);
          println!("{:16} {:>12} bytes", name, after - before);
          drop(dfa);
      }
  }


```

CPU

```rust
use aho_corasick::{automaton::Automaton, dfa::DFA, nfa::contiguous, Input};
  use std::time::Instant;

  fn speed<F: FnMut() -> u64>(name: &str, bytes: usize, iters: usize, mut f: F) {
      let mut best = f64::INFINITY;
      let mut count = 0;
      for _ in 0..iters {
          let t = Instant::now();
          count = f();
          best = best.min(t.elapsed().as_secs_f64());
      }
      println!("{:36} {:8.0} MB/s ({})", name, bytes as f64 / best / 1e6, count);
  }      

  fn main() {
      let p7: Vec<String> = (0..7_000u32).map(|i| format!("{:04x}", i)).collect();
      let p100: Vec<String> =
          (0..100_000u32).map(|i| format!("{:04x}{:x}", i % 65536, i / 65536)).collect();

      let mut best = f64::INFINITY;
      for _ in 0..5 {
          let t = Instant::now(); 
          std::hint::black_box(DFA::new(&p100).unwrap());
          best = best.min(t.elapsed().as_secs_f64());
      }
      println!("{:36} {:8.1} ms", "build DFA 100k", best * 1e3);
         
      let d7 = DFA::new(&p7).unwrap();
      let d100 = DFA::new(&p100).unwrap();
      let n7 = contiguous::NFA::new(&p7).unwrap();

      // Deterministic xorshift so every branch scans identical bytes.
      let mut seed = 0x9e3779b97f4a7c15u64;
      let mut rand = move || {
          seed ^= seed << 13; seed ^= seed >> 7; seed ^= seed << 17; seed
      };
      const HEX: &[u8] = b"0123456789abcdef";
      let hex: Vec<u8> = (0..16_000_000).map(|_| HEX[(rand() as usize) % 16]).collect();
      let junk: Vec<u8> =
          (0..16_000_000).map(|_| b"ghijklmnopqrstuv"[(rand() as usize) % 16]).collect();
      let mut sparse = junk.clone();
      let mut i = 512;
      while i < sparse.len() { sparse[i] = b'0'; i += 1024; }

      speed("DFA 7k   find_iter match-heavy", hex.len(), 10, || {
          d7.try_find_iter(Input::new(&hex)).unwrap().count() as u64
      });
      speed("DFA 100k find_iter match-heavy", hex.len(), 8, || {
          d100.try_find_iter(Input::new(&hex)).unwrap().count() as u64
      });
      speed("DFA 7k   overlapping match-heavy", hex.len(), 8, || {
          d7.try_find_overlapping_iter(Input::new(&hex)).unwrap().count() as u64
      });
      speed("DFA 100k overlapping match-heavy", hex.len(), 6, || {
          d100.try_find_overlapping_iter(Input::new(&hex)).unwrap().count() as u64
      });
      speed("DFA 7k   overlapping sparse", sparse.len(), 20, || {
          d7.try_find_overlapping_iter(Input::new(&sparse)).unwrap().count() as u64
      });
      speed("NFA 7k   overlapping match-heavy", hex.len(), 6, || {
          n7.try_find_overlapping_iter(Input::new(&hex)).unwrap().count() as u64
      });
  }

```