### PR TITLE
api: check for overflow in Match::offset too

### DIFF
--- a/src/util/search.rs
+++ b/src/util/search.rs
@@ -962,15 +962,14 @@ impl Match {
 
     /// Returns a new match with `offset` added to its span's `start` and `end`
     /// values.
+    ///
+    /// # Panics
+    ///
+    /// This panics if adding `offset` to either part of this match's `Span`
+    /// would result in overflow.
     #[inline]
     pub fn offset(&self, offset: usize) -> Match {
-        Match {
-            pattern: self.pattern,
-            span: Span {
-                start: self.start() + offset,
-                end: self.end() + offset,
-            },
-        }
+        Match { pattern: self.pattern, span: self.span.offset(offset) }
     }
 }
 


### PR DESCRIPTION
Commit 0f3f5da ("api: document a couple panicking preconditions") documented the overflow panic of `Span::offset` and made it explicit via `checked_add`, but `Match::offset` kept the unchecked additions. Consequently, with debug assertions enabled it panics with the generic "attempt to add with overflow" message rather than the documented one, and in release builds it silently produces a wrapped, nonsensical span instead of panicking:

```rust
let m = Match::must(0, usize::MAX..usize::MAX);
let m2 = m.offset(1); // release: Match with span 0..0
```

This PR delegates `Match::offset` to `Span::offset` and documents the panic in the same style. Test suite passes.

Found by running Kani's [autoharness](https://model-checking.github.io/kani/reference/experimental/autoharness.html) (model-checking/kani#3832) over aho-corasick 1.1.4, where both `offset` methods were reported; `Span::offset` is already fixed on main, so only `Match::offset` remained.
